### PR TITLE
IMU covariance using Euler packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This example is currently able to decode the following packets into ROS messages
 - ANPP 0: Acknowledge Packet
 - ANPP 3: Device Information Packet
 - ANPP 20: System State Packet
+- ANPP 26: Euler Orientation Standard Deviation Packet
 - ANPP 28: Raw Sensors Packet
 - ANPP 33: ECEF Position Packet  
 

--- a/adnav_driver/include/adnav_driver/adnav_driver.h
+++ b/adnav_driver/include/adnav_driver/adnav_driver.h
@@ -133,7 +133,7 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
 
  private:
     // Debug variables
-    int pub_num_ = 0, P28_num_ = 0, P20_num_ = 0, P27_num_ = 0, P33_num_ = 0, P0_num_ = 0;
+    int pub_num_ = 0, P28_num_ = 0, P20_num_ = 0, P26_num_ = 0, P33_num_ = 0, P0_num_ = 0;
 
     // Defines what communication method to use, refer to adnav_driver_connection_e.
     int communication_state_;
@@ -297,7 +297,7 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     void deviceInfoDecoder(an_packet_t* an_packet);
     void systemStateRosDecoder(an_packet_t* an_packet);
     void ecefPosRosDecoder(an_packet_t* an_packet);
-    void quartOrientSDRosDriver(an_packet_t* an_packet);
+    void eulerOrientSDRosDriver(an_packet_t* an_packet);
     void rawSensorsRosDecoder(an_packet_t* an_packet);
 };
 


### PR DESCRIPTION
The driver was using 3 out of 4 quaternion standard deviation values and populating the ROS2 IMU message orientation covariance matrix with them.

This covariance matrix is intended to be row major about the x, y, and z axes as detailed here:
https://docs.ros2.org/foxy/api/sensor_msgs/msg/Imu.html

As such, I'm not sure it is valid to populate this matrix with standard deviation values from a quaternion. I think a more representative value can be obtained by using ANPP 26, euler standard deviation, and converting it to covariance.

I have replaced the ANPP 27 decoder instead of adding the ANPP 26 decoder because ANPP 27 doesn't seem as usable for the message types included in this driver.