### PR TITLE
Replaced ssh submodule with https submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "an-ros-common"]
 	path = an-ros-common
-	url = git@github.com:advanced-navigation/an-ros-common.git
+	url = https://github.com/advanced-navigation/an-ros-common.git


### PR DESCRIPTION
It is more common that systems will be able to clone http repositories and relying on an ssh submodule breaks some tooling that doesn't have an ssh key configured.