### PR TITLE
fix: resolve issues with pitch direction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       package: ${{ inputs.package }}
       build_kilted: ${{ inputs.build_kilted }}
       build_iron: ${{ inputs.build_iron }}
-      package_dir: packages
+      package_dir: .
       public: false
     secrets:
       token: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Tag & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        type: choice
+        description: 'If not specified, all packages will be released.'
+        options:
+          - adnav_driver
+          - adnav_interfaces
+
+      build_kilted:
+        type: boolean
+        default: true
+        description: "Release for Kilted"
+
+      build_iron:
+        type: boolean
+        default: false
+        description: "Release for Iron"
+
+
+jobs:
+  release:
+    uses: Greenroom-Robotics/ros_semantic_release_action/.github/workflows/release.yml@main
+    with:
+      package: ${{ inputs.package }}
+      build_kilted: ${{ inputs.build_kilted }}
+      build_iron: ${{ inputs.build_iron }}
+      package_dir: packages
+      public: false
+    secrets:
+      token: ${{ secrets.API_TOKEN_GITHUB }}

--- a/adnav_driver/CMakeLists.txt
+++ b/adnav_driver/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(geographic_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(adnav_interfaces REQUIRED)
 
 # Build
@@ -54,6 +55,7 @@ set(DEPENDENCIES
   "diagnostic_updater"
   "geometry_msgs"
   "tf2"
+  "tf2_geometry_msgs"
   "adnav_interfaces"
   "geographic_msgs"
 )

--- a/adnav_driver/CMakeLists.txt
+++ b/adnav_driver/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.5)
-set(CMAKE_BUILD_TYPE release)
 project(adnav_driver)
 
 # Default to C99
@@ -9,7 +8,7 @@ endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -26,7 +25,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(diagnostic_msgs REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(geographic_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
@@ -52,7 +51,7 @@ set(DEPENDENCIES
   "std_msgs"
   "std_srvs"
   "sensor_msgs"
-  "diagnostic_msgs"
+  "diagnostic_updater"
   "geometry_msgs"
   "tf2"
   "adnav_interfaces"
@@ -67,17 +66,9 @@ add_executable(${EXECUTABLE_NAME} src/main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${PROJECT_NAME}_lib)
 ament_target_dependencies(${EXECUTABLE_NAME} ${DEPENDENCIES})
 
-# add_executable(srv_test src/srv_test.cpp)
-# target_link_libraries(srv_test ${PROJECT_NAME}_lib)
-# ament_target_dependencies(srv_test ${DEPENDENCIES})
-
 install(TARGETS ${EXECUTABLE_NAME}
   DESTINATION lib/${PROJECT_NAME}
 )
-
-# install(TARGETS srv_test
-#   DESTINATION lib/${PROJECT_NAME}
-# )
 
 install(
   DIRECTORY include/

--- a/adnav_driver/CMakeLists.txt
+++ b/adnav_driver/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(geographic_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(adnav_interfaces REQUIRED)
@@ -55,6 +56,7 @@ set(DEPENDENCIES
   "geometry_msgs"
   "tf2"
   "adnav_interfaces"
+  "geographic_msgs"
 )
 
 set(EXECUTABLE_NAME "adnav_driver")

--- a/adnav_driver/CMakeLists.txt
+++ b/adnav_driver/CMakeLists.txt
@@ -98,5 +98,4 @@ if(BUILD_TESTING)
   ament_cpplint()
 endif()
 
-ament_export_include_directories(include)
 ament_package()

--- a/adnav_driver/CMakeLists.txt
+++ b/adnav_driver/CMakeLists.txt
@@ -32,8 +32,8 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(adnav_interfaces REQUIRED)
 find_package(generate_parameter_library REQUIRED)
-find_package(libuv REQUIRED)
 find_package(uvw REQUIRED)
+
 
 
 include_directories(
@@ -70,10 +70,10 @@ generate_parameter_library(
         adnav_parameters
         src/adnav_parameters.yaml
 )
-target_link_libraries(${PROJECT_NAME}_lib adnav_parameters uvw::uvw libuv::uv_a)
+target_link_libraries(${PROJECT_NAME}_lib adnav_parameters uvw::uvw)
 
 add_executable(${EXECUTABLE_NAME} src/main.cpp)
-target_link_libraries(${EXECUTABLE_NAME} ${PROJECT_NAME}_lib uvw::uvw libuv::uv_a)
+target_link_libraries(${EXECUTABLE_NAME} ${PROJECT_NAME}_lib uvw::uvw)
 ament_target_dependencies(${EXECUTABLE_NAME} ${DEPENDENCIES})
 
 install(TARGETS ${EXECUTABLE_NAME}

--- a/adnav_driver/CMakeLists.txt
+++ b/adnav_driver/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_C_STANDARD)
 endif()
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 23)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -32,9 +32,10 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(adnav_interfaces REQUIRED)
 find_package(generate_parameter_library REQUIRED)
+find_package(libuv REQUIRED)
+find_package(uvw REQUIRED)
 
 
-# Build
 include_directories(
   include/adnav_driver
   ../an-ros-common/include
@@ -69,10 +70,10 @@ generate_parameter_library(
         adnav_parameters
         src/adnav_parameters.yaml
 )
-target_link_libraries(${PROJECT_NAME}_lib adnav_parameters)
+target_link_libraries(${PROJECT_NAME}_lib adnav_parameters uvw::uvw libuv::uv_a)
 
 add_executable(${EXECUTABLE_NAME} src/main.cpp)
-target_link_libraries(${EXECUTABLE_NAME} ${PROJECT_NAME}_lib)
+target_link_libraries(${EXECUTABLE_NAME} ${PROJECT_NAME}_lib uvw::uvw libuv::uv_a)
 ament_target_dependencies(${EXECUTABLE_NAME} ${DEPENDENCIES})
 
 install(TARGETS ${EXECUTABLE_NAME}

--- a/adnav_driver/CMakeLists.txt
+++ b/adnav_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.28)
 project(adnav_driver)
 
 # Default to C99
@@ -6,7 +6,6 @@ if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)
 endif()
 
-# Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -32,6 +31,8 @@ find_package(std_srvs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(adnav_interfaces REQUIRED)
+find_package(generate_parameter_library REQUIRED)
+
 
 # Build
 include_directories(
@@ -63,6 +64,12 @@ set(DEPENDENCIES
 set(EXECUTABLE_NAME "adnav_driver")
 
 ament_target_dependencies(${PROJECT_NAME}_lib ${DEPENDENCIES})
+
+generate_parameter_library(
+        adnav_parameters
+        src/adnav_parameters.yaml
+)
+target_link_libraries(${PROJECT_NAME}_lib adnav_parameters)
 
 add_executable(${EXECUTABLE_NAME} src/main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${PROJECT_NAME}_lib)

--- a/adnav_driver/CMakeLists.txt
+++ b/adnav_driver/CMakeLists.txt
@@ -34,10 +34,7 @@ find_package(adnav_interfaces REQUIRED)
 find_package(generate_parameter_library REQUIRED)
 find_package(uvw REQUIRED)
 
-
-
 include_directories(
-  include/adnav_driver
   ../an-ros-common/include
 )
 
@@ -78,11 +75,6 @@ ament_target_dependencies(${EXECUTABLE_NAME} ${DEPENDENCIES})
 
 install(TARGETS ${EXECUTABLE_NAME}
   DESTINATION lib/${PROJECT_NAME}
-)
-
-install(
-  DIRECTORY include/
-  DESTINATION include
 )
 
 if(BUILD_TESTING)

--- a/adnav_driver/include/adnav_driver/adnav_driver.h
+++ b/adnav_driver/include/adnav_driver/adnav_driver.h
@@ -67,12 +67,16 @@
 #include <sensor_msgs/msg/time_reference.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/temperature.hpp>
 #include <sensor_msgs/msg/fluid_pressure.hpp>
 #include <std_srvs/srv/empty.hpp>
+#include <geographic_msgs/msg/geo_pose.hpp>
+#include <geographic_msgs/msg/geo_pose_stamped.hpp>
 
 #if defined(WIN32) || defined(_WIN32)
     #pragma comment(lib, "ws2_32.lib")  // Winsock Library
@@ -167,7 +171,11 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     sensor_msgs::msg::FluidPressure baro_msg_;
     sensor_msgs::msg::Temperature   temp_msg_;
     geometry_msgs::msg::Twist       twist_msg_;
+    geometry_msgs::msg::TwistStamped twist_stamped_msg_;
+    geometry_msgs::msg::PoseStamped pose_stamped_msg_;
     geometry_msgs::msg::Pose        pose_msg_;
+    geographic_msgs::msg::GeoPose   geo_pose_msg_;
+    geographic_msgs::msg::GeoPoseStamped geo_pose_stamped_msg_;
     diagnostic_msgs::msg::DiagnosticStatus system_status_msg_;
     diagnostic_msgs::msg::DiagnosticStatus filter_status_msg_;
 
@@ -179,7 +187,11 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     rclcpp::Publisher<sensor_msgs::msg::FluidPressure>::SharedPtr 			barometric_pressure_pub_;
     rclcpp::Publisher<sensor_msgs::msg::Temperature>::SharedPtr 			temperature_pub_;
     rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr 				twist_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr 			twist_stamped_pub_;
     rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr 					pose_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr 			pose_stamped_pub_;
+    rclcpp::Publisher<geographic_msgs::msg::GeoPose>::SharedPtr 			geo_pose_pub_;
+    rclcpp::Publisher<geographic_msgs::msg::GeoPoseStamped>::SharedPtr 		geo_pose_stamped_pub_;
     rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr 	system_status_pub_;
     rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr 	filter_status_pub_;
 

--- a/adnav_driver/include/adnav_driver/adnav_driver.h
+++ b/adnav_driver/include/adnav_driver/adnav_driver.h
@@ -145,6 +145,9 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     // String to hold frame_id
     std::string frame_id_ = "imu_link";
 
+    // Whether to convert twist from ENU to FLU
+    bool convert_twist_enu_to_flu_ = false;
+
     // device communication settings
     std::unique_ptr<adnav::Communicator> communicator_;
     adnav_connections_data_t comms_data_;

--- a/adnav_driver/include/adnav_driver/adnav_driver.h
+++ b/adnav_driver/include/adnav_driver/adnav_driver.h
@@ -141,9 +141,6 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     // String to hold frame_id
     std::string frame_id_ = "imu_link";
 
-    // String to hold node name.
-    std::string node_name_;
-
     // device communication settings
     std::unique_ptr<adnav::Communicator> communicator_;
     adnav_connections_data_t comms_data_;

--- a/adnav_driver/include/adnav_driver/adnav_driver.h
+++ b/adnav_driver/include/adnav_driver/adnav_driver.h
@@ -223,11 +223,9 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     std::chrono::microseconds read_timer_interval_;
 
     // Service Handlers
-    rclcpp::Service<adnav_interfaces::srv::PacketPeriods>::SharedPtr packet_period_srv_;
     rclcpp::Service<adnav_interfaces::srv::PacketTimerPeriod>::SharedPtr packet_period_timer_srv_;
     rclcpp::Service<std_srvs::srv::Empty>::SharedPtr restart_pub_srv_;
     rclcpp::Service<std_srvs::srv::Empty>::SharedPtr restart_read_srv_;
-    rclcpp::Service<adnav_interfaces::srv::RequestPackets>::SharedPtr request_packet_srv_;
     rclcpp::Service<adnav_interfaces::srv::Ntrip>::SharedPtr ntrip_srv_;
 
     // Threading variables
@@ -264,17 +262,12 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     void RestartReader();
 
     //~~~~~~ Logging Functions
-    void openLogFile();
     void system_status_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
     void filter_status_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
 
     //~~~~~~ ROS Services
-    void srvPacketPeriods(const std::shared_ptr<adnav_interfaces::srv::PacketPeriods::Request> request,
-            std::shared_ptr<adnav_interfaces::srv::PacketPeriods::Response> response);
     void srvPacketTimerPeriod(const std::shared_ptr<adnav_interfaces::srv::PacketTimerPeriod::Request> request,
             std::shared_ptr<adnav_interfaces::srv::PacketTimerPeriod::Response> response);
-    void srvRequestPackets(const std::shared_ptr<adnav_interfaces::srv::RequestPackets::Request> request,
-        std::shared_ptr<adnav_interfaces::srv::RequestPackets::Response> response);
     void srvNtrip(const std::shared_ptr<adnav_interfaces::srv::Ntrip::Request> request,
         std::shared_ptr<adnav_interfaces::srv::Ntrip::Response> response);
 
@@ -290,7 +283,6 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     void updatePacketRequest(const rclcpp::Parameter& parameter);
     rcl_interfaces::msg::SetParametersResult validatePacketTimer(const rclcpp::Parameter& parameter);
     void updatePacketTimer(const rclcpp::Parameter& parameter);
-    void validateAndSaveIPAddress(const rclcpp::Parameter& parameter);
 
     //~~~~~~ NTRIP Functions
     void updateNTRIPClientService();

--- a/adnav_driver/include/adnav_driver/adnav_driver.h
+++ b/adnav_driver/include/adnav_driver/adnav_driver.h
@@ -51,6 +51,8 @@
 #include <adnav_logger.h>
 #include <adnav_ntrip.h>
 
+#include <adnav_driver/adnav_parameters.hpp>
+
 // Adnav_interfaces
 #include <adnav_interfaces/srv/packet_periods.hpp>
 #include <adnav_interfaces/srv/packet_timer_period.hpp>
@@ -139,25 +141,16 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     // Debug variables
     int pub_num_ = 0, P28_num_ = 0, P20_num_ = 0, P27_num_ = 0, P33_num_ = 0, P0_num_ = 0;
 
-    // Defines what communication method to use, refer to adnav_driver_connection_e.
-    int communication_state_;
+    std::shared_ptr<adnav::ParamListener> param_listener_;
 
     // String to hold frame_id
     std::string frame_id_ = "imu_link";
-
-    // Whether to convert twist from ENU to FLU
-    bool convert_twist_enu_to_flu_ = false;
+    std::string external_frame_id_ = "map";
 
     // device communication settings
     std::unique_ptr<adnav::Communicator> communicator_;
-    adnav_connections_data_t comms_data_;
-
-    // Packet settings;
-    std::vector<int64_t> packet_request_;
-    int packet_timer_period_;
 
     // Log files.
-    std::string log_path_;
     adnav::Logger anpp_logger_;
     adnav::Logger rtcm_logger_;
 
@@ -218,9 +211,6 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     // Timers
     rclcpp::TimerBase::SharedPtr publish_timer_;
     rclcpp::TimerBase::SharedPtr read_timer_;
-    // Timer intervals
-    std::chrono::microseconds publish_timer_interval_;
-    std::chrono::microseconds read_timer_interval_;
 
     // Service Handlers
     rclcpp::Service<adnav_interfaces::srv::PacketTimerPeriod>::SharedPtr packet_period_timer_srv_;
@@ -253,7 +243,6 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     void createServices();
     void deviceSetup();
     void setupParamService();
-    void setupParams();
 
     //~~~~~~ Control Functions
     void recievePackets();
@@ -272,6 +261,7 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
         std::shared_ptr<adnav_interfaces::srv::Ntrip::Response> response);
 
     //~~~~~~ Parameter Functions
+    std::vector<adnav_interfaces::msg::PacketPeriod> getPacketRequest();
     rcl_interfaces::msg::SetParametersResult ParamSetCallback(const std::vector<rclcpp::Parameter>& Params);
     rcl_interfaces::msg::SetParametersResult validateBaudRate(const rclcpp::Parameter& parameter);
     rcl_interfaces::msg::SetParametersResult validateComPort(const rclcpp::Parameter& parameter);

--- a/adnav_driver/include/adnav_driver/adnav_driver.h
+++ b/adnav_driver/include/adnav_driver/adnav_driver.h
@@ -176,10 +176,12 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     sensor_msgs::msg::Temperature   temp_msg_;
     geometry_msgs::msg::Twist       twist_msg_;
     geometry_msgs::msg::TwistStamped twist_stamped_msg_;
+    geometry_msgs::msg::TwistStamped twist_stamped_msg_external_body;
     geometry_msgs::msg::PoseStamped pose_stamped_msg_;
     geometry_msgs::msg::Pose        pose_msg_;
     geographic_msgs::msg::GeoPose   geo_pose_msg_;
     geographic_msgs::msg::GeoPoseStamped geo_pose_stamped_msg_;
+
 
     std::shared_ptr<diagnostic_updater::Updater> diagnostic_updater_;
 
@@ -192,6 +194,7 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     rclcpp::Publisher<sensor_msgs::msg::Temperature>::SharedPtr 			temperature_pub_;
     rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr 				twist_pub_;
     rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr 			twist_stamped_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr 			twist_stamped_external_body_pub_;
     rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr 					pose_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr 			pose_stamped_pub_;
     rclcpp::Publisher<geographic_msgs::msg::GeoPose>::SharedPtr 			geo_pose_pub_;
@@ -310,6 +313,8 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     void ecefPosRosDecoder(an_packet_t* an_packet);
     void quartOrientSDRosDriver(an_packet_t* an_packet);
     void rawSensorsRosDecoder(an_packet_t* an_packet);
+    void extBodyVelRosDecoder(an_packet_t *an_packet);
+    void bodyVelRosDecoder(an_packet_t *an_packet);
 };
 
 }  // namespace adnav

--- a/adnav_driver/package.xml
+++ b/adnav_driver/package.xml
@@ -16,6 +16,7 @@
   <depend>geometry_msgs</depend>
   <depend>geographic_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>std_srvs</depend>
   <depend>adnav_interfaces</depend>
 

--- a/adnav_driver/package.xml
+++ b/adnav_driver/package.xml
@@ -14,6 +14,7 @@
   <depend>sensor_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>geographic_msgs</depend>
   <depend>tf2</depend>
   <depend>std_srvs</depend>
   <depend>adnav_interfaces</depend>

--- a/adnav_driver/package.xml
+++ b/adnav_driver/package.xml
@@ -12,7 +12,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
   <depend>geographic_msgs</depend>
   <depend>tf2</depend>

--- a/adnav_driver/package.xml
+++ b/adnav_driver/package.xml
@@ -20,6 +20,8 @@
   <depend>std_srvs</depend>
   <depend>adnav_interfaces</depend>
 
+  <build_depend>generate_parameter_library</build_depend>
+
   <!-- <test_depend>ament_lint_auto</test_depend> -->
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/adnav_driver/package.xml
+++ b/adnav_driver/package.xml
@@ -21,6 +21,7 @@
   <depend>adnav_interfaces</depend>
 
   <build_depend>generate_parameter_library</build_depend>
+  <build_depend>uvw_vendor</build_depend>
 
   <!-- <test_depend>ament_lint_auto</test_depend> -->
   <test_depend>ament_cmake_cpplint</test_depend>

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -191,7 +191,7 @@ void Driver::createServices() {
 			this,
 			std::placeholders::_1,
 			std::placeholders::_2),
-		rmw_qos_profile_services_default,
+		rclcpp::ServicesQoS(),
 		service_group_);
 
 	packet_period_timer_srv_ = this->create_service<adnav_interfaces::srv::PacketTimerPeriod>(
@@ -201,7 +201,7 @@ void Driver::createServices() {
 			this,
 			std::placeholders::_1,
 			std::placeholders::_2),
-		rmw_qos_profile_services_default,
+		rclcpp::ServicesQoS(),
 		service_group_);
 
 	request_packet_srv_ = this->create_service<adnav_interfaces::srv::RequestPackets>(
@@ -211,7 +211,7 @@ void Driver::createServices() {
 			this,
 			std::placeholders::_1,
 			std::placeholders::_2),
-		rmw_qos_profile_services_default,
+		rclcpp::ServicesQoS(),
 		service_group_);
 
 	ntrip_srv_ = this->create_service<adnav_interfaces::srv::Ntrip>(
@@ -221,7 +221,7 @@ void Driver::createServices() {
 			this,
 			std::placeholders::_1,
 			std::placeholders::_2),
-		rmw_qos_profile_services_default,
+		rclcpp::ServicesQoS(),
 		service_group_);
 }
 

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -95,19 +95,22 @@ Driver::Driver(): rclcpp::Node("adnav_driver"), msg_write_done_(false)
  * Closes the Logfiles and gives name to the user. Shutsdown the communication method
  */
 Driver::~Driver() {
-	RCLCPP_INFO(this->get_logger(), "Destructing Adnav_Driver node");
+	RCLCPP_INFO(this->get_logger(), "Deconstructing Adnav_Driver node");
 
 	anpp_logger_.closeFile();
 
 	// if the Ntrip client is initialised and running or the logger is open.
-	if (ntrip_client_.get() != nullptr && (ntrip_client_->service_running() || rtcm_logger_.is_open())) {
+	if (ntrip_client_ && (ntrip_client_->service_running() || rtcm_logger_.is_open())) {
 		ntrip_client_->stop();
 
 		// Close the logfile
 		rtcm_logger_.closeFile();
 	}
 
-	communicator_->close();
+	if (communicator_)
+	{
+		communicator_->close();
+	}
 }
 
 rclcpp::Time time_from_state_packet(const system_state_packet_t& state_packet) {

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -53,10 +53,6 @@ Driver::Driver(): rclcpp::Node("adnav_driver"), msg_write_done_(false)
 	// Setup parameters for the node
 	setupParamService();
 
-	// Get the name of the node
-	node_name_ = this->get_name();
-	RCLCPP_INFO(this->get_logger(), "\nNamespace: %s\n", node_name_.c_str());
-
 	// Create timers for callbacks
 	publish_timer_ = this->create_wall_timer(
       	publish_timer_interval_ , std::bind(&Driver::publishTimerCallback, this), publishing_group_);
@@ -168,16 +164,16 @@ void Driver::requestDeviceInfo() {
  */
 void Driver::createPublishers() {
 	// Creating the ROS2 Publishers
-	imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>(std::string(node_name_ + "/imu"), 10);
-	imu_raw_pub_ = this->create_publisher<sensor_msgs::msg::Imu>(std::string(node_name_ + "/imu_raw"), 10);
-	nav_sat_fix_pub_ = this->create_publisher<sensor_msgs::msg::NavSatFix>(std::string(node_name_ + "/nav_sat_fix"), 10);
-	magnetic_field_pub_ = this->create_publisher<sensor_msgs::msg::MagneticField>(std::string(node_name_ + "/magnetic_field"), 10);
-	barometric_pressure_pub_ = this->create_publisher<sensor_msgs::msg::FluidPressure>(std::string(node_name_ + "/barometric_pressure"), 10);
-	temperature_pub_ = this->create_publisher<sensor_msgs::msg::Temperature>(std::string(node_name_ + "/temperature"), 10);
-	twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>(std::string(node_name_ + "/twist"), 10);
-	pose_pub_ = this->create_publisher<geometry_msgs::msg::Pose>(std::string(node_name_ + "/pose"), 10);
-	system_status_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticStatus>(std::string(node_name_ + "/system_status"), 10);
-	filter_status_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticStatus>(std::string(node_name_ + "/filter_status"), 10);
+	imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("~/imu", 10);
+	imu_raw_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("~/imu_raw", 10);
+	nav_sat_fix_pub_ = this->create_publisher<sensor_msgs::msg::NavSatFix>("~/nav_sat_fix", 10);
+	magnetic_field_pub_ = this->create_publisher<sensor_msgs::msg::MagneticField>("~/magnetic_field", 10);
+	barometric_pressure_pub_ = this->create_publisher<sensor_msgs::msg::FluidPressure>("~/barometric_pressure", 10);
+	temperature_pub_ = this->create_publisher<sensor_msgs::msg::Temperature>("~/temperature", 10);
+	twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("~/twist", 10);
+	pose_pub_ = this->create_publisher<geometry_msgs::msg::Pose>("~/pose", 10);
+	system_status_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticStatus>("~/system_status", 10);
+	filter_status_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticStatus>("~/filter_status", 10);
 }
 
 /**
@@ -185,7 +181,7 @@ void Driver::createPublishers() {
  */
 void Driver::createServices() {
 	packet_period_srv_ = this->create_service<adnav_interfaces::srv::PacketPeriods>(
-		(node_name_ + "/packet_periods"),
+		"~/packet_periods",
 		std::bind(
 			&Driver::srvPacketPeriods,
 			this,
@@ -195,7 +191,7 @@ void Driver::createServices() {
 		service_group_);
 
 	packet_period_timer_srv_ = this->create_service<adnav_interfaces::srv::PacketTimerPeriod>(
-		(node_name_ + "/packet_timer_period"),
+		"~/packet_timer_period",
 		std::bind(
 			&Driver::srvPacketTimerPeriod,
 			this,
@@ -205,7 +201,7 @@ void Driver::createServices() {
 		service_group_);
 
 	request_packet_srv_ = this->create_service<adnav_interfaces::srv::RequestPackets>(
-		(node_name_ + "/request_packet"),
+		"~/request_packet",
 		std::bind(
 			&Driver::srvRequestPackets,
 			this,
@@ -215,7 +211,7 @@ void Driver::createServices() {
 		service_group_);
 
 	ntrip_srv_ = this->create_service<adnav_interfaces::srv::Ntrip>(
-		(node_name_ + "/ntrip"),
+		"~/ntrip",
 		std::bind(
 			&Driver::srvNtrip,
 			this,

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -42,9 +42,6 @@ namespace adnav {
 Driver::Driver(): rclcpp::Node("adnav_driver")
 {
 	// ~~~~~~~~~~ Create the callback groups
-	// Callback group only for reading ANPP Packets
-	reading_group_ 		= this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-
 	// Multithreaded group for publishing ROS messages
 	publishing_group_	= this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
 
@@ -81,10 +78,10 @@ Driver::Driver(): rclcpp::Node("adnav_driver")
 			std::shared_ptr<uvw::tcp_handle> tcp_handle;
 			std::shared_ptr<uvw::udp_handle> udp_handle;
 
-			if (_params.comm_select == 1)
+			if (_params.connection_type == "tcp-client")
 			{
 				tcp_handle = loop->resource<uvw::tcp_handle>();
-			} else if (_params.comm_select == 3)
+			} else if (_params.connection_type == "udp")
 			{
 				udp_handle = loop->resource<uvw::udp_handle>();
 			}

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -26,7 +26,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "adnav_driver.h"
+#include "adnav_driver.hpp"
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -68,6 +68,10 @@ Driver::Driver(): rclcpp::Node("adnav_driver")
 
 	createPublishers();
 
+	system_state_packet_.set_lifespan(std::chrono::microseconds(params.publish_us * 3));
+	euler_orientation_standard_deviation_packet_.set_lifespan(std::chrono::microseconds(params.publish_us * 3));
+	velocity_standard_deviation_packet_.set_lifespan(std::chrono::microseconds(params.publish_us * 3));
+
 	connection_thread_ = std::jthread([&](std::stop_token st){
 		auto loop = uvw::loop::get_default();
 
@@ -182,10 +186,17 @@ Driver::Driver(): rclcpp::Node("adnav_driver")
 					receivePackets(buffer);
 				});
 
-				udp_handle->bind(uvw::socket_address{_params.ip_address_local, static_cast<unsigned int>(_params.port)});
+				// determine the correct local address to listen on
+				udp_handle->connect(dest);
+				auto local_addr = udp_handle->sock();
+				local_addr.port = static_cast<unsigned int>(_params.port);
+				udp_handle->disconnect();
+
+				udp_handle->bind(local_addr);
 				udp_handle->recv();
 
-				RCLCPP_INFO(this->get_logger(), "UDP: Created endpoint %s:%ld", _params.ip_address.c_str(), _params.port);
+				RCLCPP_INFO(this->get_logger(), "UDP: Created %s:%u --> endpoint %s:%u", local_addr.ip.c_str(), local_addr.port,
+					dest.ip.c_str(), dest.port);
 
 				// Run setup in a separate thread so it can block on request-reply futures
 				// without stalling the event loop. join() is fast — failAllPendingReplies() will
@@ -233,6 +244,7 @@ Driver::Driver(): rclcpp::Node("adnav_driver")
 	diagnostic_updater_->add("System Status", this, &Driver::system_status_diagnostic);
 	diagnostic_updater_->add("Filter Status", this, &Driver::filter_status_diagnostic);
 	diagnostic_updater_->add("Accuracy", this, &Driver::accuracy_diagnostic);
+	diagnostic_updater_->add("Packets", this, &Driver::packets_diagnostic);
 }
 
 /**
@@ -325,19 +337,19 @@ bool Driver::requestDeviceInfo() {
  */
 void Driver::createPublishers() {
 	// Creating the ROS2 Publishers
-	imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("~/imu", 10);
-	imu_raw_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("~/imu_raw", 10);
-	nav_sat_fix_pub_ = this->create_publisher<sensor_msgs::msg::NavSatFix>("~/nav_sat_fix", 10);
-	magnetic_field_pub_ = this->create_publisher<sensor_msgs::msg::MagneticField>("~/magnetic_field", 10);
-	barometric_pressure_pub_ = this->create_publisher<sensor_msgs::msg::FluidPressure>("~/barometric_pressure", 10);
-	temperature_pub_ = this->create_publisher<sensor_msgs::msg::Temperature>("~/temperature", 10);
-	twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("~/twist", 10);
-	twist_stamped_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("~/twist_stamped", 10);
-	twist_stamped_external_body_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("~/twist_stamped_external_body", 10);
-	pose_pub_ = this->create_publisher<geometry_msgs::msg::Pose>("~/pose", 10);
-	pose_stamped_pub_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("~/pose_stamped", 10);
-	geo_pose_pub_ = this->create_publisher<geographic_msgs::msg::GeoPose>("~/geopose", 10);
-	geo_pose_stamped_pub_ = this->create_publisher<geographic_msgs::msg::GeoPoseStamped>("~/geopose_stamped", 10);
+	imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu", 10);
+	imu_raw_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_raw", 10);
+	nav_sat_fix_pub_ = this->create_publisher<sensor_msgs::msg::NavSatFix>("nav_sat_fix", 10);
+	magnetic_field_pub_ = this->create_publisher<sensor_msgs::msg::MagneticField>("magnetic_field", 10);
+	barometric_pressure_pub_ = this->create_publisher<sensor_msgs::msg::FluidPressure>("barometric_pressure", 10);
+	temperature_pub_ = this->create_publisher<sensor_msgs::msg::Temperature>("temperature", 10);
+	twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("twist", 10);
+	twist_stamped_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("twist_stamped", 10);
+	twist_stamped_external_body_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("twist_stamped_external_body", 10);
+	pose_pub_ = this->create_publisher<geometry_msgs::msg::Pose>("pose", 10);
+	pose_stamped_pub_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("pose_stamped", 10);
+	geo_pose_pub_ = this->create_publisher<geographic_msgs::msg::GeoPose>("geopose", 10);
+	geo_pose_stamped_pub_ = this->create_publisher<geographic_msgs::msg::GeoPoseStamped>("geopose_stamped", 10);
 }
 
 /**
@@ -370,7 +382,7 @@ void Driver::deviceSetup() {
 
 	const auto params = param_listener_->get_params();
 	SendPacketTimer(params.packet_timer_period);
-	SendPacketPeriods(getPacketRequest());
+	SendPacketPeriods(getPacketRequest(), params.override_existing_packets);
 }
 
 /**
@@ -481,79 +493,72 @@ void Driver::RestartPublisher() {
 
 void Driver::system_status_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat)
 {
-	if (system_state_packet_.has_value())
+	const auto sys_state_pkt = system_state_packet_.value();
+	if (sys_state_pkt)
 	{
-		auto last_rx_time = time_from_state_packet(system_state_packet_.value());
-
-		if (this->get_clock()->now() - last_rx_time < rclcpp::Duration(1, 0))
-		{
-			stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "System State packet timeout");
-			return;
-		}
-
 		stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
 
-		if (system_state_packet_->system_status.b.system_failure) {
+		if (sys_state_pkt->system_status.b.system_failure) {
 			stat.add("System", "Fail");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.accelerometer_sensor_failure) {
+		if (sys_state_pkt->system_status.b.accelerometer_sensor_failure) {
 			stat.add("Accelerometer", "Fail");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.gyroscope_sensor_failure) {
+		if (sys_state_pkt->system_status.b.gyroscope_sensor_failure) {
 			stat.add("Gyroscope", "Fail");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.magnetometer_sensor_failure) {
+		if (sys_state_pkt->system_status.b.magnetometer_sensor_failure) {
 			stat.add("Magnetometer", "Fail");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.pressure_sensor_failure) {
+		if (sys_state_pkt->system_status.b.pressure_sensor_failure) {
 			stat.add("Pressure Sensor", "Fail");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.gnss_failure) {
+		if (sys_state_pkt->system_status.b.gnss_failure) {
 			stat.add("GNSS", "Fail");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.accelerometer_over_range) {
+		if (sys_state_pkt->system_status.b.accelerometer_over_range) {
 			stat.add("Accelerometer Over Range", "Fail");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.gyroscope_over_range) {
+		if (sys_state_pkt->system_status.b.gyroscope_over_range) {
 			stat.add("Gyroscope Over Range", "Fail");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.magnetometer_over_range) {
+		if (sys_state_pkt->system_status.b.magnetometer_over_range) {
 			stat.add("Magnetometer", " Over Range");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.pressure_over_range) {
+		if (sys_state_pkt->system_status.b.pressure_over_range) {
 			stat.add("Pressure Sensor", " Over Range");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.minimum_temperature_alarm) {
+		if (sys_state_pkt->system_status.b.minimum_temperature_alarm) {
 			stat.add("Temperature Alarm", "Minimum Temperature Alarm");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.maximum_temperature_alarm) {
+		if (sys_state_pkt->system_status.b.maximum_temperature_alarm) {
 			stat.add("Temperature Alarm", "Maximum Temperature Alarm");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.internal_data_logging_error) {
+		if (sys_state_pkt->system_status.b.internal_data_logging_error) {
 			stat.add("Data Logging", "Internal Error");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.high_voltage_alarm) {
+		if (sys_state_pkt->system_status.b.high_voltage_alarm) {
 			stat.add("Power Supply", "High Voltage Alarm");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.gnss_antenna_fault) {
+		if (sys_state_pkt->system_status.b.gnss_antenna_fault) {
 			stat.add("GNSS Antenna", "Fault Detected");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (system_state_packet_->system_status.b.serial_port_overflow_alarm) {
+		if (sys_state_pkt->system_status.b.serial_port_overflow_alarm) {
 			stat.add("Serial Port", "Data Overflow");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
@@ -565,47 +570,71 @@ void Driver::system_status_diagnostic(diagnostic_updater::DiagnosticStatusWrappe
 			stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "System Failure Detected");
 		}
 	} else {
-		stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "System State packet not received");
+		stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, std::format("System State packet: {}", to_string(sys_state_pkt.error())));
 	}
 }
 
 void Driver::filter_status_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat)
 {
-	if (system_state_packet_.has_value())
-	{
-		auto last_rx_time = time_from_state_packet(system_state_packet_.value());
-
-		if (this->get_clock()->now() - last_rx_time < rclcpp::Duration(1, 0))
-		{
-			stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "System State packet timeout");
-			return;
-		}
-
+	const auto sys_state_pkt = system_state_packet_.value();
+	if (sys_state_pkt) {
 		stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
 
-		stat.add("Orientation Filter Initialised", system_state_packet_->filter_status.b.orientation_filter_initialised ? "Yes" : "No");
-		stat.add("Navigation Filter Initialised", system_state_packet_->filter_status.b.ins_filter_initialised ? "Yes" : "No");
-		stat.add("Heading Initialised", system_state_packet_->filter_status.b.heading_initialised ? "Yes" : "No");
-		stat.add("UTC Time Initialised", system_state_packet_->filter_status.b.utc_time_initialised ? "Yes" : "No");
-		stat.add("Internal GNSS Enabled", system_state_packet_->filter_status.b.internal_gnss_enabled ? "Yes" : "No");
-		stat.add("Dual Antenna Heading Active", system_state_packet_->filter_status.b.dual_antenna_heading_active ? "Yes" : "No");
-		stat.add("Velocity Heading Enabled", system_state_packet_->filter_status.b.velocity_heading_enabled ? "Yes" : "No");
-		stat.add("Atmospheric Altitude Enabled", system_state_packet_->filter_status.b.atmospheric_altitude_enabled ? "Yes" : "No");
-		stat.add("External Position Active", system_state_packet_->filter_status.b.external_position_active ? "Yes" : "No");
-		stat.add("External Velocity Active", system_state_packet_->filter_status.b.external_velocity_active ? "Yes" : "No");
-		stat.add("External Heading Active", system_state_packet_->filter_status.b.external_heading_active ? "Yes" : "No");
+		stat.add("Orientation Filter Initialised", sys_state_pkt->filter_status.b.orientation_filter_initialised ? "Yes" : "No");
+		stat.add("Navigation Filter Initialised", sys_state_pkt->filter_status.b.ins_filter_initialised ? "Yes" : "No");
+		stat.add("Heading Initialised", sys_state_pkt->filter_status.b.heading_initialised ? "Yes" : "No");
+		stat.add("UTC Time Initialised", sys_state_pkt->filter_status.b.utc_time_initialised ? "Yes" : "No");
+		stat.add("Internal GNSS Enabled", sys_state_pkt->filter_status.b.internal_gnss_enabled ? "Yes" : "No");
+		stat.add("Dual Antenna Heading Active", sys_state_pkt->filter_status.b.dual_antenna_heading_active ? "Yes" : "No");
+		stat.add("Velocity Heading Enabled", sys_state_pkt->filter_status.b.velocity_heading_enabled ? "Yes" : "No");
+		stat.add("Atmospheric Altitude Enabled", sys_state_pkt->filter_status.b.atmospheric_altitude_enabled ? "Yes" : "No");
+		stat.add("External Position Active", sys_state_pkt->filter_status.b.external_position_active ? "Yes" : "No");
+		stat.add("External Velocity Active", sys_state_pkt->filter_status.b.external_velocity_active ? "Yes" : "No");
+		stat.add("External Heading Active", sys_state_pkt->filter_status.b.external_heading_active ? "Yes" : "No");
 
-		const auto gnss_fix = static_cast<GnssFixStatus>(system_state_packet_->filter_status.b.gnss_fix_type);
+		const auto gnss_fix = static_cast<GnssFixStatus>(sys_state_pkt->filter_status.b.gnss_fix_type);
 		stat.add("GNSS Fix Status", to_string(gnss_fix));
 
 		// TODO parameters need to be added to inform what is considered abnormal operation
 
 		stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
 	} else {
-		stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "System State packet not received");
+		stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, std::format("System State packet: {}", to_string(sys_state_pkt.error())));
 	}
 }
 
+	void Driver::packets_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat)
+{
+	stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+
+	auto packets = getPacketRequest();
+
+	for (const auto& packet: packets)
+	{
+		const auto packet_name = packet_id_to_string(static_cast<packet_id_e>(packet.packet_id)).value_or("Packet ID " + std::to_string(packet.packet_id));
+
+		if (packet_receive_times.contains(packet.packet_id))
+		{
+			auto last_rx_time = packet_receive_times[packet.packet_id];
+			auto time_since_last = this->get_clock()->now() - last_rx_time;
+			stat.add(std::format("{} ({}) - Last Seen (ms)", packet_name, packet.packet_id), std::to_string(time_since_last.nanoseconds() / 1e6));
+
+			if (time_since_last > rclcpp::Duration(1, 0))
+			{
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, std::format("{} stale", packet_name).c_str());
+			}
+		} else
+		{
+			stat.add(std::format("{} ({}) - Last Seen (ms)", packet_name, packet.packet_id), "Never");
+			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, std::format("{} packet never received", packet_name).c_str());
+		}
+
+		if (stat.level == diagnostic_msgs::msg::DiagnosticStatus::OK)
+		{
+			stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
+		}
+	}
+}
 
 /**
  * Calculate positional accuracy from the standard deviation values in the system state packet.
@@ -640,41 +669,34 @@ double orientation_accuracy_stdev(const euler_orientation_standard_deviation_pac
 
 void Driver::accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat)
 {
-	if (system_state_packet_.has_value())
+	const auto sys_state_pkt = system_state_packet_.value();
+	if (sys_state_pkt)
 	{
-		auto last_rx_time = time_from_state_packet(system_state_packet_.value());
-
-		if (this->get_clock()->now() - last_rx_time < rclcpp::Duration(1, 0))
-		{
-			stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "System State packet timeout");
-			return;
-		}
-
 		const auto params = param_listener_->get_params();
 
 		stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
 
 		if (params.health.filters_initialised)
 		{
-			if (!system_state_packet_->filter_status.b.orientation_filter_initialised) {
+			if (!sys_state_pkt->filter_status.b.orientation_filter_initialised) {
 				stat.add("Orientation Filter", "Not Initialised");
 				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Orientation Filter not initialised");
 			}
 
-			if (!system_state_packet_->filter_status.b.ins_filter_initialised)
+			if (!sys_state_pkt->filter_status.b.ins_filter_initialised)
 			{
 				stat.add("Navigation Filter", "Not Initialised");
 				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Navigation Filter not initialised");
 			}
 
-			if (!system_state_packet_->filter_status.b.heading_initialised)
+			if (!sys_state_pkt->filter_status.b.heading_initialised)
 			{
 				stat.add("Heading", "Not Initialised");
 				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Heading not initialised");
 			}
 		}
 
-		const auto gnss_fix = static_cast<GnssFixStatus>(system_state_packet_->filter_status.b.gnss_fix_type);
+		const auto gnss_fix = static_cast<GnssFixStatus>(sys_state_pkt->filter_status.b.gnss_fix_type);
 		stat.add("GNSS Fix Status", to_string(gnss_fix));
 
 		if (params.health.gnss_fix && gnss_fix != GnssFixStatus::Fix3D)
@@ -684,14 +706,14 @@ void Driver::accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &st
 
 		if (params.health.external_velocity)
 		{
-			stat.add("External Velocity Active", system_state_packet_->filter_status.b.external_velocity_active ? "Yes" : "No");
-			if (!system_state_packet_->filter_status.b.external_velocity_active)
+			stat.add("External Velocity Active", sys_state_pkt->filter_status.b.external_velocity_active ? "Yes" : "No");
+			if (!sys_state_pkt->filter_status.b.external_velocity_active)
 			{
 				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No External Velocity");
 			}
 		}
 
-		auto [rms_2d, rms_3d] = position_accuracy_rms(*system_state_packet_);
+		auto [rms_2d, rms_3d] = position_accuracy_rms(*sys_state_pkt);
 		stat.add("Position Accuracy (2D RMS) (m)", std::to_string(rms_2d));
 		stat.add("Position Accuracy (3D RMS) (m)", std::to_string(rms_3d));
 
@@ -704,8 +726,9 @@ void Driver::accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &st
 			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "3D Position RMS above threshold");
 		}
 
-		if (euler_orientation_standard_deviation_packet_.has_value()) {
-			const auto orientation_deviation = orientation_accuracy_stdev(*euler_orientation_standard_deviation_packet_);
+		const auto euler_stddev_pkt = euler_orientation_standard_deviation_packet_.value();
+		if (euler_stddev_pkt) {
+			const auto orientation_deviation = orientation_accuracy_stdev(*euler_stddev_pkt);
 			stat.add("Orientation Deviation (max of roll, pitch, yaw) (rads)", std::to_string(orientation_deviation));
 			if (params.health.thresholds.orientation_accuracy_stdev != 0.0 && orientation_deviation > params.health.thresholds.orientation_accuracy_stdev)
 			{
@@ -713,21 +736,28 @@ void Driver::accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &st
 			}
 		} else if (params.health.thresholds.orientation_accuracy_stdev != 0.0)
 		{
-			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Cannot calculate Orientation stdev");
+			stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, std::format("Euler Orientation Stddev packet: {}", to_string(euler_stddev_pkt.error())));
 		}
 
-		auto [vel_rms_2d, vel_rms_3d] = velocity_accuracy_rms(*velocity_standard_deviation_packet_);
-		stat.add("Velocity Accuracy (2D RMS) (m)", std::to_string(vel_rms_2d));
-		stat.add("Velocity Accuracy (3D RMS) (m)", std::to_string(vel_rms_3d));
-
-		if (params.health.thresholds.velocity_accuracy_rms_2d != 0.0 && vel_rms_2d > params.health.thresholds.velocity_accuracy_rms_2d)
+		const auto velocity_stddev_pkt = velocity_standard_deviation_packet_.value();
+		if (velocity_stddev_pkt)
 		{
-			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "2D Velocity RMS above threshold");
-		}
+			auto [vel_rms_2d, vel_rms_3d] = velocity_accuracy_rms(*velocity_stddev_pkt);
+			stat.add("Velocity Accuracy (2D RMS) (m)", std::to_string(vel_rms_2d));
+			stat.add("Velocity Accuracy (3D RMS) (m)", std::to_string(vel_rms_3d));
 
-		if (params.health.thresholds.velocity_accuracy_rms_3d != 0.0 && vel_rms_3d > params.health.thresholds.velocity_accuracy_rms_3d)
+			if (params.health.thresholds.velocity_accuracy_rms_2d != 0.0 && vel_rms_2d > params.health.thresholds.velocity_accuracy_rms_2d)
+			{
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "2D Velocity RMS above threshold");
+			}
+
+			if (params.health.thresholds.velocity_accuracy_rms_3d != 0.0 && vel_rms_3d > params.health.thresholds.velocity_accuracy_rms_3d)
+			{
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "3D Velocity RMS above threshold");
+			}
+		} else if (params.health.thresholds.velocity_accuracy_rms_2d != 0.0 || params.health.thresholds.velocity_accuracy_rms_3d != 0.0)
 		{
-			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "3D Velocity RMS above threshold");
+			stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, std::format("Velocity Standard Deviation packet: {}", to_string(velocity_stddev_pkt.error())));
 		}
 
 		if (stat.level == diagnostic_msgs::msg::DiagnosticStatus::OK)
@@ -1070,11 +1100,11 @@ std::vector<adnav_interfaces::msg::PacketPeriod> Driver::getPacketRequest() {
 
 	if (params.send_packet_periods)
 	{
-		for (const auto& pkt : REQUIRED_PACKETS)
+		for (const auto pkt_id : REQUIRED_PACKETS)
 		{
 			adnav_interfaces::msg::PacketPeriod period;
-			period.packet_id = pkt.packet_id;
-			period.packet_period = pkt.period.count();
+			period.packet_id = pkt_id;
+			period.packet_period = params.default_packet_period;
 			packet_periods.push_back(period);
 		}
 
@@ -1220,11 +1250,8 @@ void Driver::getDataFromHostStr(const std::string& host) {
 
 	ntrip_state_.ip = std::string(ip);
 
-
 	// Get the Port from the string
 	ntrip_state_.port = atoi(split_string.back().c_str());
-
-	return;
 }
 
 /**
@@ -1461,6 +1488,8 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 		// Decode all the packets in the buffer
 		std::unique_lock<std::mutex> lock(messages_mutex_);
 
+		auto buffer_ts = now();
+
 		while ((an_packet = an_packet_decode(&an_decoder)) != nullptr)
 		 {
 			RCLCPP_DEBUG(this->get_logger(), "RX Packet IDs %hhu", an_packet->id);
@@ -1481,14 +1510,20 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 				break;
 
 			case packet_id_euler_orientation_standard_deviation:
-				euler_orientation_standard_deviation_packet_.emplace();
-				decode_euler_orientation_standard_deviation_packet(&*euler_orientation_standard_deviation_packet_, an_packet);
-				break;
+				{
+					euler_orientation_standard_deviation_packet_t pkt;
+					decode_euler_orientation_standard_deviation_packet(&pkt, an_packet);
+					euler_orientation_standard_deviation_packet_ = pkt;
+					break;
+				}
 
 			case packet_id_velocity_standard_deviation:
-				velocity_standard_deviation_packet_.emplace();
-				decode_velocity_standard_deviation_packet(&*velocity_standard_deviation_packet_, an_packet);
-				break;
+				{
+					velocity_standard_deviation_packet_t pkt;
+					decode_velocity_standard_deviation_packet(&pkt, an_packet);
+					velocity_standard_deviation_packet_ = pkt;
+					break;
+				}
 
 			case packet_id_raw_sensors: rawSensorsRosDecoder(an_packet);
 				break;
@@ -1505,6 +1540,8 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 				handled = false;
 				break;
 			}
+
+			packet_receive_times.insert_or_assign(an_packet->id, buffer_ts);
 
 			// Generic pending reply dispatch — fires for any packet_id registered in pending_replies_.
 			// Runs alongside named case handlers, so both can fire for the same packet (e.g. device info

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -31,17 +31,16 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace adnav {
+
+
 /**
  * @brief Constructor for the Advanced Navigation Driver node
  *
  * This will create a Driver instance. Declare node parameters, setup threading groups and callbacks.
  * Initialize the log file, and open the communications to the device.
  */
-Driver::Driver(): rclcpp::Node("adnav_driver"), msg_write_done_(false)
+Driver::Driver(): rclcpp::Node("adnav_driver")
 {
-	// Set default values
-	memset(&acknowledge_packet_, -1, sizeof(acknowledge_packet_));
-
 	// ~~~~~~~~~~ Create the callback groups
 	// Callback group only for reading ANPP Packets
 	reading_group_ 		= this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -65,39 +64,178 @@ Driver::Driver(): rclcpp::Node("adnav_driver"), msg_write_done_(false)
 		std::chrono::microseconds(params.publish_us), std::bind(&Driver::publishTimerCallback, this),
 		publishing_group_);
 
-	read_timer_ = this->create_wall_timer(
-		std::chrono::microseconds(params.read_us), std::bind(&Driver::recievePackets, this), reading_group_);
-
-	// Setup Services for the node
 	createServices();
 
 	// Open a new ANPP Log file for data logging
 	anpp_logger_.openFile("Log_", ".anpp", params.log_path);
 
-	// Open Communications with the device
-
-	adnav_connections_data_t comms_data {};
-	comms_data.method = params.comm_select;
-	comms_data.com_port = params.com_port;
-	comms_data.ip_address = params.ip_address;
-	comms_data.port = params.port;
-
-	communicator_ = std::make_unique<adnav::Communicator>(comms_data);
-	communicator_->open();
-
-	// Request device info with Packet 1 and 3
-	waitForDevicePacket();
-
-	// Create Publishers for the node
 	createPublishers();
 
-	// Send current setup of timer period, and packet periods to the device.
-	deviceSetup();
+	connection_thread_ = std::jthread([&](std::stop_token st){
+		auto loop = uvw::loop::get_default();
+
+		while (!st.stop_requested()) {
+			const auto _params = param_listener_->get_params();
+			auto dest = uvw::socket_address{_params.ip_address, static_cast<unsigned int>(_params.port)};
+
+			std::shared_ptr<uvw::tcp_handle> tcp_handle;
+			std::shared_ptr<uvw::udp_handle> udp_handle;
+
+			if (_params.comm_select == 1)
+			{
+				tcp_handle = loop->resource<uvw::tcp_handle>();
+			} else if (_params.comm_select == 3)
+			{
+				udp_handle = loop->resource<uvw::udp_handle>();
+			}
+
+			close_async_ = loop->resource<uvw::async_handle>();
+			close_async_->on<uvw::async_event>([&](const uvw::async_event &, uvw::async_handle &async) {
+				// This fires on the loop thread — safe to close handles here
+				if (tcp_handle) {
+					tcp_handle->stop();
+				}
+				if (udp_handle) {
+					udp_handle->stop();
+				}
+				if (write_async_) {
+					write_async_->close();
+				}
+				async.close();  // close the async handle itself so the loop can exit
+			});
+
+			write_async_ = loop->resource<uvw::async_handle>();
+			write_async_->on<uvw::async_event>([&](const uvw::async_event &, uvw::async_handle &) {
+				std::unique_lock lock(write_q_mutex_);
+				while (!write_q_.empty()) {
+					auto [data, size] = std::move(write_q_.front());
+					write_q_.pop();
+					lock.unlock();
+					if (tcp_handle)
+					{
+						tcp_handle->write(std::move(data), size);
+					}
+					if (udp_handle)
+					{
+						udp_handle->send(dest, std::move(data), size);
+					}
+					lock.lock();
+				}
+			});
+
+			if (tcp_handle)
+			{
+				tcp_handle->on<uvw::error_event>([&](const uvw::error_event &err, uvw::tcp_handle &)
+				{
+					RCLCPP_ERROR(rclcpp::get_logger("adnav_driver"), "TCP: Connection Error: %s - stopping", err.what());
+					failAllPendingReplies();
+					close_async_->send();
+				});
+
+				tcp_handle->on<uvw::end_event>([&](const uvw::end_event &, uvw::tcp_handle &) {
+					RCLCPP_INFO(rclcpp::get_logger("adnav_driver"), "TCP: End Event");
+					failAllPendingReplies();
+					close_async_->send();
+				});
+
+				tcp_handle->on<uvw::connect_event>([&](const uvw::connect_event &, uvw::tcp_handle &tcp) {
+					RCLCPP_INFO(this->get_logger(), "TCP: Connection established");
+					// tcp.keep_alive(true, uvw::tcp_handle::time{2});
+
+					if (const auto err = uv_tcp_keepalive_ex(tcp.raw(), 1, 1, 1, 2); err != 0) {
+						RCLCPP_ERROR(this->get_logger(), "Failed to set TCP keep-alive: %s", uv_strerror(err));
+						throw std::runtime_error("Failed to set TCP keep-alive");
+					}
+					tcp.read();
+
+					// Run setup in a separate thread so it can block on request-reply futures
+					// without stalling the event loop. join() is fast — failAllPendingReplies() will
+					// have unblocked any in-flight future before we reach here on reconnect.
+					if (setup_thread_.joinable()) setup_thread_.join();
+					setup_thread_ = std::jthread([this] {
+						requestDeviceInfo();
+						deviceSetup();
+					});
+				});
+
+				tcp_handle->on<uvw::data_event>([&](const uvw::data_event &event, uvw::tcp_handle &) {
+					std::span<const uint8_t> buffer(
+						reinterpret_cast<const uint8_t*>(event.data.get()), event.length);
+					RCLCPP_DEBUG(this->get_logger(), "Received %zu bytes", buffer.size());
+					receivePackets(buffer);
+				});
+
+				RCLCPP_INFO(this->get_logger(), "TCP: Attempting to connect to %s:%ld", _params.ip_address.c_str(), _params.port);
+				tcp_handle->connect(dest);
+			}
+
+			if (udp_handle)
+			{
+				udp_handle->on<uvw::error_event>([&](const uvw::error_event &err, uvw::udp_handle &)
+				{
+					RCLCPP_ERROR(rclcpp::get_logger("adnav_driver"), "UDP: Connection Error: %s - stopping", err.what());
+					failAllPendingReplies();
+					close_async_->send();
+				});
+
+				udp_handle->on<uvw::udp_data_event>([&](const uvw::udp_data_event &event, uvw::udp_handle &) {
+					std::span<const uint8_t> buffer(
+						reinterpret_cast<const uint8_t*>(event.data.get()), event.length);
+					RCLCPP_DEBUG(this->get_logger(), "Received %zu bytes", buffer.size());
+					receivePackets(buffer);
+				});
+
+				udp_handle->bind(uvw::socket_address{_params.ip_address_local, static_cast<unsigned int>(_params.port)});
+				udp_handle->recv();
+
+				RCLCPP_INFO(this->get_logger(), "UDP: Created endpoint %s:%ld", _params.ip_address.c_str(), _params.port);
+
+				// Run setup in a separate thread so it can block on request-reply futures
+				// without stalling the event loop. join() is fast — failAllPendingReplies() will
+				// have unblocked any in-flight future before we reach here on reconnect.
+				if (setup_thread_.joinable()) setup_thread_.join();
+				setup_thread_ = std::jthread([this] {
+					if (!requestDeviceInfo())
+					{
+						RCLCPP_ERROR(rclcpp::get_logger("adnav_driver"), "Did not get a Device Information reply - stopping");
+						close_async_->send();
+						return;
+					}
+					deviceSetup();
+				});
+			}
+
+			loop->run();
+			RCLCPP_DEBUG(this->get_logger(), "Event loop ended");
+
+			if (tcp_handle)
+			{
+				tcp_handle->close();
+			}
+
+			if (udp_handle)
+			{
+				udp_handle->close();
+			}
+
+			if (!st.stop_requested())
+			{
+				RCLCPP_ERROR(this->get_logger(), "Attempting reconnect in 2 seconds");
+				std::condition_variable_any cv;
+				std::mutex mtx;
+				std::stop_callback cb(st, [&]
+				{
+					cv.notify_all();
+				});
+				std::unique_lock lock(mtx);
+				cv.wait_for(lock, st, std::chrono::seconds(2), [&st]{ return st.stop_requested(); });
+			}
+		}
+	});
 
 	diagnostic_updater_->add("System Status", this, &Driver::system_status_diagnostic);
 	diagnostic_updater_->add("Filter Status", this, &Driver::filter_status_diagnostic);
-
-	RCLCPP_DEBUG(this->get_logger(), "Your Advanced Navigation ROS driver is currently running\nPress Ctrl-C to interrupt\n");
+	diagnostic_updater_->add("Accuracy", this, &Driver::accuracy_diagnostic);
 }
 
 /**
@@ -118,10 +256,11 @@ Driver::~Driver() {
 		rtcm_logger_.closeFile();
 	}
 
-	if (communicator_)
-	{
-		communicator_->close();
+	connection_thread_.request_stop();
+	if (close_async_) {
+		close_async_->send();  // ← thread-safe wakeup
 	}
+	connection_thread_.join();
 }
 
 rclcpp::Time time_from_state_packet(const system_state_packet_t& state_packet) {
@@ -139,59 +278,49 @@ rclcpp::Time time_from_state_packet(const system_state_packet_t& state_packet) {
 }
 
 /**
- * @brief Function to ask for device information from a Advanced navigation device and wait for its response.
- */
-void Driver::waitForDevicePacket() {
-	// initialize the decoder.
-	an_decoder_t an_decoder;
-	an_packet_t *an_packet;
-	an_decoder_initialise(&an_decoder);
-	bool recieved = false;
-	int bytes_received;
-
-	RCLCPP_DEBUG(this->get_logger(), "Requesting Device Info");
-
-	while(recieved == false && rclcpp::ok()) {
-		// Request the device to send the Device info packet.
-		requestDeviceInfo();
-
-		// Read in some data from the connection.
-		bytes_received = communicator_->read(an_decoder_pointer(&an_decoder), an_decoder_size(&an_decoder));
-
-		// Decode all data and act on only the device info data.
-		if (bytes_received > 0)
-		 {
-			anpp_logger_.writeAndIncrement(reinterpret_cast<char*>(an_decoder_pointer(&an_decoder)), bytes_received);
-
-			// Increment the decode buffer length by the number of bytes received
-			an_decoder_increment(&an_decoder, bytes_received);
-
-			while ((an_packet = an_packet_decode(&an_decoder)) != nullptr)
-			 {
-				RCLCPP_DEBUG(this->get_logger(), "[WaitForDevicePacket]ID: %d", an_packet->id);
-
-				if(an_packet->id == packet_id_device_information) {
-					RCLCPP_DEBUG(this->get_logger(), "Received Device Information Packet (ANPP.3)");
-					deviceInfoDecoder(an_packet);
-					recieved = true;
-
-				}
-
-				// Ensure that you free the an_packet when your done with it or you will leak memory
-				an_packet_free(&an_packet);
-			}
-		}
-	}
-}
-
-/**
  * @brief Function to request a Advanced Navigation Devices info using ANPP.
  */
-void Driver::requestDeviceInfo() {
-	an_packet_t* an_packet;
+bool Driver::requestDeviceInfo() {
+	RCLCPP_DEBUG(this->get_logger(), "Requesting Device Info");
+	auto promise = std::make_shared<std::promise<device_information_packet_t>>();
+	auto future = promise->get_future();
 
-	an_packet = encode_request_packet(packet_id_device_information);
+	{
+		std::lock_guard lock(pending_replies_mutex_);
+		pending_replies_[packet_id_device_information] = {
+			[promise](an_packet_t* pkt) {
+				device_information_packet_t decoded_pkt{};
+				if (decode_device_information_packet(&decoded_pkt, pkt)) {
+					promise->set_exception(std::make_exception_ptr(
+						std::runtime_error("Decode error")));
+					return;
+				}
+				try { promise->set_value(decoded_pkt); } catch (const std::future_error&) {}
+			},
+			[promise](std::exception_ptr ep) {
+				try { promise->set_exception(ep); } catch (const std::future_error&) {}
+			}
+		};
+	}
+
+	an_packet_t* an_packet = encode_request_packet(packet_id_device_information);
 	encodeAndSend(an_packet);
+
+	if (future.wait_for(std::chrono::seconds(DEFAULT_TIMEOUT)) != std::future_status::ready) {
+		RCLCPP_ERROR(this->get_logger(), "Reply timeout for Device Information");
+		std::lock_guard lock(pending_replies_mutex_);
+		pending_replies_.erase(packet_id_device_information);
+		return false;
+	}
+
+	try {
+		[[maybe_unused]] const auto pkt = future.get();
+		return true;
+	} catch (const std::exception& e) {
+		// Promise was broken by failAllPendingReplies() — connection dropped mid-wait
+		RCLCPP_ERROR(this->get_logger(), "ACK aborted for Device Information: %s", e.what());
+		return false;
+	}
 }
 
 /**
@@ -243,14 +372,8 @@ void Driver::deviceSetup() {
 	RCLCPP_INFO(this->get_logger(), "Sending requested configuration to device:");
 
 	const auto params = param_listener_->get_params();
-
-	// Create and send a Packet Timer Period Packet.
-	acknowledge_recieve_ = true; // Since we are not waiting for device acknowledgement at startup
-	SendPacketTimer(params.packet_timer_period); // Will overwrite acknowledge_receive_ to false
-
-	// Since we are not waiting for device acknowledgement at startup
-	acknowledge_recieve_ = true;
-	SendPacketPeriods(getPacketRequest()); // Will overwrite acknowledge_receive_ to false.
+	SendPacketTimer(params.packet_timer_period);
+	SendPacketPeriods(getPacketRequest());
 }
 
 /**
@@ -276,12 +399,6 @@ void Driver::setupParamService() {
 					this,
 					std::placeholders::_1));
 
-	// read period updater callback
-	read_us_cb_ = param_handler_->add_parameter_callback("read_us",
-			std::bind(&Driver::updateReadUs,
-					this,
-					std::placeholders::_1));
-
 	// packet request updater callback
 	packet_request_cb_ = param_handler_->add_parameter_callback("packet_request",
 			std::bind(&Driver::updatePacketRequest,
@@ -304,16 +421,17 @@ void Driver::setupParamService() {
  *
  * This Function will also create a log file session and log incoming data to it.
  */
-void Driver::recievePackets() {
-	// initialize the decoder.
+void Driver::receivePackets(const std::span<const uint8_t> buffer) {
 	an_decoder_t an_decoder;
 	an_decoder_initialise(&an_decoder);
-	int bytes_received;
 
-	// get the bytes from the communication method, and load them into the decoder
-	bytes_received = communicator_->read(an_decoder_pointer(&an_decoder), an_decoder_size(&an_decoder));
+	// Copy incoming data into the decoder buffer
+	const auto buffer_bytes = std::min(buffer.size(), an_decoder_size(&an_decoder));
+	std::memcpy(an_decoder_pointer(&an_decoder), buffer.data(), buffer_bytes);
 
-	decodePackets(an_decoder, bytes_received);
+	anpp_logger_.writeAndIncrement(reinterpret_cast<char*>(an_decoder_pointer(&an_decoder)), buffer_bytes);
+	an_decoder_increment(&an_decoder, buffer_bytes);
+	decodePackets(an_decoder, buffer_bytes);
 }
 
 /**
@@ -323,27 +441,13 @@ void Driver::recievePackets() {
  * Awaits a signal from a ROS Decoder method before publishing and accessing shared data.
  */
 void Driver::publishTimerCallback() {
-	// Since the messages can be filled in other threads ensure exclusive access.
-	std::unique_lock<std::mutex> lock(messages_mutex_);
-
-	// Debug timekeeper value
-	rcl_time_point_value_t time = 0, diff = 0;
-
-	// Check for updates from other threads.
-	if(!msg_write_done_) {
-		time = this->get_clock().get()->now().nanoseconds();
-		// Only wait until timeout. otherwise log error and exit callback.
-		if (msg_cv_.wait_for(lock, std::chrono::milliseconds(DEFAULT_TIMEOUT)) == std::cv_status::timeout) {
-			RCLCPP_DEBUG(this->get_logger(), "Publish Timeout");
-			if(time) diff = this->get_clock().get()->now().nanoseconds() - time;
-			RCLCPP_DEBUG(this->get_logger(), "PubTimeout:\tAccess: %d\tTimeWait: %ld μs", pub_num_, diff/1000);
-			return;
-		}
+	if (!write_async_ || !write_async_->active())
+	{
+		return;
 	}
 
-	// Debug message to show how long it waited to be awoken.
-	if(time) diff = this->get_clock().get()->now().nanoseconds() - time;
-	RCLCPP_DEBUG(this->get_logger(), "Pub: \t\tMutex: L\tAccess: %d\tTimeWait: %ld μs", pub_num_, diff/1000);
+	// Since the messages can be filled in other threads ensure exclusive access.
+	std::unique_lock<std::mutex> lock(messages_mutex_);
 
 	// PUBLISH MESSAGES
 	nav_sat_fix_pub_->publish(nav_fix_msg_);
@@ -359,11 +463,6 @@ void Driver::publishTimerCallback() {
 	pose_stamped_pub_->publish(pose_stamped_msg_);
 	geo_pose_pub_->publish(geo_pose_msg_);
 	geo_pose_stamped_pub_->publish(geo_pose_stamped_msg_);
-
-	RCLCPP_DEBUG(this->get_logger(), "Pub: \t\tMutex: U\tAccess: %d", pub_num_++);
-
-	// Restore the blocking flag before exiting the lock guard.
-	msg_write_done_ = false;
 }
 
 /**
@@ -379,22 +478,6 @@ void Driver::RestartPublisher() {
 	// Reset the timer using the class stored interval.
 	publish_timer_ = this->create_wall_timer(
       	std::chrono::microseconds(params.publish_us), std::bind(&Driver::publishTimerCallback, this), publishing_group_);
-}
-
-/**
- * @brief Function to cancel and restart the Reader timer.
- */
-void Driver::RestartReader() {
-	RCLCPP_INFO(this->get_logger(), "Restarting Reader Timer");
-
-	// Cancel old timer to stop callbacks from triggering while remaking timer.
-	read_timer_->cancel();
-
-	const auto params = param_listener_->get_params();
-
-	// Reset the timer using the class stored interval.
-	read_timer_ = this->create_wall_timer(
-		std::chrono::microseconds(params.read_us), std::bind(&Driver::recievePackets, this), reading_group_);
 }
 
 //~~~~~~ Diagnostic Functions
@@ -501,6 +584,8 @@ void Driver::filter_status_diagnostic(diagnostic_updater::DiagnosticStatusWrappe
 			return;
 		}
 
+		stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+
 		stat.add("Orientation Filter Initialised", system_state_packet_->filter_status.b.orientation_filter_initialised ? "Yes" : "No");
 		stat.add("Navigation Filter Initialised", system_state_packet_->filter_status.b.ins_filter_initialised ? "Yes" : "No");
 		stat.add("Heading Initialised", system_state_packet_->filter_status.b.heading_initialised ? "Yes" : "No");
@@ -513,9 +598,136 @@ void Driver::filter_status_diagnostic(diagnostic_updater::DiagnosticStatusWrappe
 		stat.add("External Velocity Active", system_state_packet_->filter_status.b.external_velocity_active ? "Yes" : "No");
 		stat.add("External Heading Active", system_state_packet_->filter_status.b.external_heading_active ? "Yes" : "No");
 
+		const auto gnss_fix = static_cast<GnssFixStatus>(system_state_packet_->filter_status.b.gnss_fix_type);
+		stat.add("GNSS Fix Status", to_string(gnss_fix));
+
 		// TODO parameters need to be added to inform what is considered abnormal operation
 
 		stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
+	} else {
+		stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "System State packet not received");
+	}
+}
+
+
+/**
+ * Calculate positional accuracy from the standard deviation values in the system state packet.
+ * @param state_packet
+ * @return double, double: 2D RMS, 3D RMS
+ */
+std::tuple<double, double> position_accuracy_rms(const system_state_packet_t& state_packet) {
+	const auto [x, y, z] = state_packet.standard_deviation;
+	return {
+		std::sqrt(std::pow(x, 2) + std::pow(y, 2)),
+		std::sqrt(std::pow(x, 2) + std::pow(y, 2) + std::pow(z, 2))
+	};
+}
+
+double orientation_accuracy_stdev(const euler_orientation_standard_deviation_packet_t& orientation_packet) {
+	const auto [roll_stdev, pitch_stdev, yaw_stdev] = orientation_packet.standard_deviation;
+	return std::max({roll_stdev, pitch_stdev, yaw_stdev});
+}
+
+/**
+ * Calculate velocity accuracy from the standard deviation values
+ * @param velocity_standard_deviation
+ * @return double, double: 2D RMS, 3D RMS
+ */
+	std::tuple<double, double> velocity_accuracy_rms(const velocity_standard_deviation_packet_t& velocity_standard_deviation) {
+	const auto [x, y, z] = velocity_standard_deviation.standard_deviation;
+	return {
+		std::sqrt(std::pow(x, 2) + std::pow(y, 2)),
+		std::sqrt(std::pow(x, 2) + std::pow(y, 2) + std::pow(z, 2))
+	};
+}
+
+void Driver::accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat)
+{
+	if (system_state_packet_.has_value())
+	{
+		auto last_rx_time = time_from_state_packet(system_state_packet_.value());
+
+		if (this->get_clock()->now() - last_rx_time < rclcpp::Duration(1, 0))
+		{
+			stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "System State packet timeout");
+			return;
+		}
+
+		const auto params = param_listener_->get_params();
+
+		stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+
+		if (params.health.filters_initialised)
+		{
+			if (!system_state_packet_->filter_status.b.orientation_filter_initialised) {
+				stat.add("Orientation Filter", "Not Initialised");
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Orientation Filter not initialised");
+			}
+
+			if (!system_state_packet_->filter_status.b.ins_filter_initialised)
+			{
+				stat.add("Navigation Filter", "Not Initialised");
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Navigation Filter not initialised");
+			}
+
+			if (!system_state_packet_->filter_status.b.heading_initialised)
+			{
+				stat.add("Heading", "Not Initialised");
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Heading not initialised");
+			}
+		}
+
+		const auto gnss_fix = static_cast<GnssFixStatus>(system_state_packet_->filter_status.b.gnss_fix_type);
+		stat.add("GNSS Fix Status", to_string(gnss_fix));
+
+		if (params.health.gnss_fix && gnss_fix != GnssFixStatus::Fix3D)
+		{
+			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No GNSS 3D Fix");
+		}
+
+		auto [rms_2d, rms_3d] = position_accuracy_rms(*system_state_packet_);
+		stat.add("Position Accuracy (2D RMS) (m)", std::to_string(rms_2d));
+		stat.add("Position Accuracy (3D RMS) (m)", std::to_string(rms_3d));
+
+		if (params.health.thresholds.position_accuracy_rms_2d != 0.0 && rms_2d > params.health.thresholds.position_accuracy_rms_2d)
+		{
+			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "2D Position RMS above threshold");
+		}
+		if (params.health.thresholds.position_accuracy_rms_3d != 0.0 && rms_3d > params.health.thresholds.position_accuracy_rms_3d)
+		{
+			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "3D Position RMS above threshold");
+		}
+
+		if (euler_orientation_standard_deviation_packet_.has_value()) {
+			const auto orientation_deviation = orientation_accuracy_stdev(*euler_orientation_standard_deviation_packet_);
+			stat.add("Orientation Deviation (max of roll, pitch, yaw) (rads)", std::to_string(orientation_deviation));
+			if (params.health.thresholds.orientation_accuracy_stdev != 0.0 && orientation_deviation > params.health.thresholds.orientation_accuracy_stdev)
+			{
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Orientation stdev above threshold");
+			}
+		} else if (params.health.thresholds.orientation_accuracy_stdev != 0.0)
+		{
+			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Cannot calculate Orientation stdev");
+		}
+
+		auto [vel_rms_2d, vel_rms_3d] = velocity_accuracy_rms(*velocity_standard_deviation_packet_);
+		stat.add("Velocity Accuracy (2D RMS) (m)", std::to_string(vel_rms_2d));
+		stat.add("Velocity Accuracy (3D RMS) (m)", std::to_string(vel_rms_3d));
+
+		if (params.health.thresholds.velocity_accuracy_rms_2d != 0.0 && vel_rms_2d > params.health.thresholds.velocity_accuracy_rms_2d)
+		{
+			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "2D Velocity RMS above threshold");
+		}
+
+		if (params.health.thresholds.velocity_accuracy_rms_3d != 0.0 && vel_rms_3d > params.health.thresholds.velocity_accuracy_rms_3d)
+		{
+			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "3D Velocity RMS above threshold");
+		}
+
+		if (stat.level == diagnostic_msgs::msg::DiagnosticStatus::OK)
+		{
+			stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
+		}
 	} else {
 		stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "System State packet not received");
 	}
@@ -532,13 +744,8 @@ void Driver::filter_status_diagnostic(diagnostic_updater::DiagnosticStatusWrappe
 void Driver::srvPacketTimerPeriod(const std::shared_ptr<adnav_interfaces::srv::PacketTimerPeriod::Request> request,
 		std::shared_ptr<adnav_interfaces::srv::PacketTimerPeriod::Response> response) {
 
-	// Send config to device.
-	SendPacketTimer(request->packet_timer_period, request->utc_synchronisation, request->permanent);
+	response->acknowledgement = SendPacketTimer(request->packet_timer_period, request->utc_synchronisation, request->permanent);
 
-	// Await the response.
-	response->acknowledgement = AcknowledgeHandler();
-
-	// notify of result.
 	char buf[15];
 	snprintf(buf, sizeof(buf)/sizeof(buf[0]), "%s%d%s", "Failure: ", response->acknowledgement.result, "\n");
 	RCLCPP_INFO(this->get_logger(), "Received Update acknowledgement:\nID: %d\tCRC: %d\nOutcome: %s", response->acknowledgement.id,
@@ -706,14 +913,10 @@ rcl_interfaces::msg::SetParametersResult Driver::ParamSetCallback(const std::vec
 
 		// Validation of parameters
 		// Only if they require validation
-		// Baud rate
-		if (parameter.get_name() == "baud_rate") result.reason += validateBaudRate(parameter).reason;
 		// comport
-		else if (parameter.get_name() == "com_port") result.reason += validateComPort(parameter).reason;
+		if (parameter.get_name() == "com_port") result.reason += validateComPort(parameter).reason;
 		// Publisher Interval Duration
 		else if (parameter.get_name() == "publish_us") result.reason += validatePublishUs(parameter).reason;
-		// Sensor Polling Interval Duration
-		else if (parameter.get_name() == "read_us") result.reason += validateReadUs(parameter).reason;
 		// Packet IDs and Rates
 		else if (parameter.get_name() == "packet_request") result.reason += validatePacketRequest(parameter).reason;
 		// Packet Timer Period
@@ -722,54 +925,6 @@ rcl_interfaces::msg::SetParametersResult Driver::ParamSetCallback(const std::vec
 
 	if(result.reason != "") {
 		result.successful = false;
-	}
-	return result;
-}
-
-/**
- * @brief Function to validate the proposed parameter change to the Baud Rate parameter.
- *
- * @param parameter const rclcpp::Parameter. proposed change to the Baud Rate parameter.
- * @return returns a SetParametersResult message containing a success value and a string descriptor.
- */
-rcl_interfaces::msg::SetParametersResult Driver::validateBaudRate(const rclcpp::Parameter& parameter) {
-	rcl_interfaces::msg::SetParametersResult result;
-	result.reason = "";
-	result.successful = true;
-
-	// Stringstream to stream in faults.
-	std::stringstream ss;
-
-	// Guard for parameter type
-	if(parameter.get_type() != rclcpp::ParameterType::PARAMETER_INTEGER) {
-		result.successful = false;
-		ss << "\n[Error] Passed parameter is not of Integer Type.\n";
-	}
-
-	// test for valid baudrate
-	switch(parameter.as_int())
-	 {
-		case    2400 : 	break;
-		case    4800 : 	break;
-		case    9600 : 	break;
-		case   19200 : 	break;
-		case   38400 : 	break;
-		case   57600 : 	break;
-		case  115200 : 	break;
-		case  230400 : 	break;
-		case  460800 : 	break;
-		case  500000 : 	break;
-		case  576000 : 	break;
-		case  921600 : 	break;
-		case 1000000 : 	break;
-		case 2000000 : 	break;
-		default      : 	result.successful = false;
-						ss << "\n[Error] Invalid Baud Rate\n";
-					   	break;
-	}
-
-	if(!result.successful)	 {
-		result.reason = ss.str();
 	}
 	return result;
 }
@@ -820,12 +975,6 @@ rcl_interfaces::msg::SetParametersResult Driver::validatePublishUs(const rclcpp:
 		ss << "\n[Error] Passed parameter is not of Integer Type.\n";
 	}
 
-	// Guard for less than read_us
-	if(parameter.as_int() < this->get_parameter("read_us").as_int()) {
-		result.successful = false;
-		ss << "\n[Error] Publish period must be greater than or equal to read period\n";
-	}
-
 	// Guard for timer range
 	if(parameter.as_int() < 1000 || parameter.as_int() > 1000000) {
 		result.successful = false;
@@ -846,58 +995,6 @@ rcl_interfaces::msg::SetParametersResult Driver::validatePublishUs(const rclcpp:
  */
 void Driver::updatePublishUs([[maybe_unused]] const rclcpp::Parameter& parameter) {
 	RestartPublisher();
-}
-
-/**
- * @brief Function to validate the proposed parameter change to the Read us parameter.
- *
- * @param parameter const rclcpp::Parameter. proposed change to the Read us parameter.
- * @return returns a SetParametersResult message containing a success value and a string descriptor.
- */
-rcl_interfaces::msg::SetParametersResult Driver::validateReadUs(const rclcpp::Parameter& parameter) {
-	rcl_interfaces::msg::SetParametersResult result;
-	result.reason = "";
-	result.successful = true;
-
-	// Stringstream to stream in faults.
-	std::stringstream ss;
-
-	// Guard for parameter type
-	if(parameter.get_type() != rclcpp::ParameterType::PARAMETER_INTEGER) {
-		result.successful = false;
-		ss << "\n[Error] Passed parameter is not of Integer Type.\n";
-	}
-
-	// Guard for timer range
-	if(parameter.as_int() < 1000 || parameter.as_int() > 1000000) {
-		result.successful = false;
-		ss << "\n[Error] Read Period " << parameter.as_int() << " is invalid. Out of range.";
-	}
-
-	// Ensure that the publish timer is not lower than the new read period.
-	try
-	 {
-		if(parameter.as_int() > this->get_parameter("publish_us").as_int()) {
-			result.successful = false;
-			ss << "[Error] Publish Period (" << this->get_parameter("publish_us").as_int() <<
-				") is less than requested read period (" << parameter.as_int() << ").\n";
-		}
-	} // This catch will be thrown on startup as read is initialized period to publish.
-	catch(const rclcpp::exceptions::ParameterNotDeclaredException& e) {}
-
-	if(!result.successful)	 {
-		result.reason = ss.str();
-	}
-	return result;
-}
-
-/**
- * @brief Function to Update the Read us parameter, create temporary service client and update node timer using service
- *
- * @param parameter const rclcpp::Parameter. updated Read us parameter
- */
-void Driver::updateReadUs([[maybe_unused]] const rclcpp::Parameter& parameter) {
-	RestartReader();
 }
 
 /**
@@ -965,12 +1062,22 @@ std::vector<adnav_interfaces::msg::PacketPeriod> Driver::getPacketRequest() {
 	std::vector<adnav_interfaces::msg::PacketPeriod> packet_periods;
 	const auto params = param_listener_->get_params();
 
-	// Create and fill a periods format.
-	for(std::size_t i = 0; (i+i) < params.packet_request.size(); i++) {
-		adnav_interfaces::msg::PacketPeriod period;
-		period.packet_id = params.packet_request[i+i];
-		period.packet_period = params.packet_request[i+i+1];
-		packet_periods.push_back(period);
+	if (params.send_packet_periods)
+	{
+		for (const auto& pkt : REQUIRED_PACKETS)
+		{
+			adnav_interfaces::msg::PacketPeriod period;
+			period.packet_id = pkt.packet_id;
+			period.packet_period = pkt.period.count();
+			packet_periods.push_back(period);
+		}
+
+		for (std::size_t i = 0; (i+i) < params.additional_packet_request.size(); i++) {
+			adnav_interfaces::msg::PacketPeriod period;
+			period.packet_id = params.additional_packet_request[i+i];
+			period.packet_period = params.additional_packet_request[i+i+1];
+			packet_periods.push_back(period);
+		}
 	}
 	return packet_periods;
 }
@@ -1168,43 +1275,96 @@ void Driver::NtripReceiveFunction(const char* buffer, int size) {
  */
 void Driver::encodeAndSend(an_packet_t* an_packet) {
 	an_packet_encode(an_packet);
-	// Send encoded packet through the selected communication medium
-	communicator_->write(an_packet_pointer(an_packet), an_packet_size(an_packet));
-	// Free the packet to avoid memory leaks
+
+	const auto size = static_cast<unsigned int>(an_packet_size(an_packet));
+	auto data = std::make_unique<char[]>(size);
+	std::memcpy(data.get(), an_packet_pointer(an_packet), size);
 	an_packet_free(&an_packet);
+
+	{
+		std::lock_guard lock(write_q_mutex_);
+		write_q_.push({std::move(data), size});
+	}
+	write_async_->send();
 }
 
 /**
- * @brief Function to handle the acknowledgement of configuration from a device in a thread safe manner.
+ * @brief Register a pending reply for the acknowledge of @p an_packet, send it,
+ *        then block until the device replies or @c DEFAULT_TIMEOUT seconds elapse.
  *
- * Needs to interact with the reading thread to receive the packet. Uses a conditional variable to flag when a
- * packet has been received.
+ * Uses pending_replies_ keyed on packet_id_acknowledge, so any caller can use the
+ * same mechanism to await any other packet type by registering their own PendingReply.
  *
- * @return Raw Acknowledge Message
+ * Thread-safe: may be called from any thread (e.g. setup_thread_ or a ROS service thread).
+ * The actual TCP write is always dispatched onto the event loop via write_async_.
+ *
+ * @param an_packet Encoded ANPP packet whose reply we are waiting for.
+ * @return RawAcknowledge message; result field is 0xFF on timeout or connection drop.
  */
-adnav_interfaces::msg::RawAcknowledge Driver::AcknowledgeHandler() {
-	// make acknowledgement data structure
-	adnav_interfaces::msg::RawAcknowledge msg;
+adnav_interfaces::msg::RawAcknowledge Driver::sendAndAwaitAck(an_packet_t* an_packet) {
+	const uint8_t packet_id = an_packet->id;
 
-	// Wait for an acknowledge packet to be received.
-	std::unique_lock<std::mutex> lock(acknowledge_mutex_);
-	if(!acknowledge_recieve_) {
-		if(srv_cv_.wait_for(lock, std::chrono::seconds(DEFAULT_TIMEOUT)) == std::cv_status::timeout) {
-			RCLCPP_ERROR(this->get_logger(), "acknowledgement Timeout");
-			msg.result++; // make error condition
-			return msg;
-		}
+	auto promise = std::make_shared<std::promise<acknowledge_packet_t>>();
+	std::future<acknowledge_packet_t> future = promise->get_future();
+
+	// Register BEFORE sending to avoid a race where the ack arrives before the entry exists.
+	{
+		std::lock_guard lock(pending_replies_mutex_);
+		pending_replies_[packet_id_acknowledge] = {
+			[promise](an_packet_t* pkt) {
+				acknowledge_packet_t ack{};
+				if (decode_acknowledge_packet(&ack, pkt)) {
+					promise->set_exception(std::make_exception_ptr(
+						std::runtime_error("Decode error")));
+					return;
+				}
+				try { promise->set_value(ack); } catch (const std::future_error&) {}
+			},
+			[promise](std::exception_ptr ep) {
+				try { promise->set_exception(ep); } catch (const std::future_error&) {}
+			}
+		};
 	}
 
-	// acknowledge_packet_
-	msg.id  = acknowledge_packet_.packet_id;
-	msg.crc = acknowledge_packet_.packet_crc;
-	msg.result = acknowledge_packet_.acknowledge_result;
+	encodeAndSend(an_packet);
 
-	// reset condition variable.
-	acknowledge_recieve_ = false;
+	adnav_interfaces::msg::RawAcknowledge msg;
+
+	if (future.wait_for(std::chrono::seconds(DEFAULT_TIMEOUT)) != std::future_status::ready) {
+		RCLCPP_ERROR(this->get_logger(), "ACK timeout for packet %d", packet_id);
+		std::lock_guard lock(pending_replies_mutex_);
+		pending_replies_.erase(packet_id_acknowledge);
+		msg.result = 0xFF;
+		return msg;
+	}
+
+	try {
+		const auto pkt = future.get();
+		msg.id     = pkt.packet_id;
+		msg.crc    = pkt.packet_crc;
+		msg.result = pkt.acknowledge_result;
+	} catch (const std::exception& e) {
+		// Promise was broken by failAllPendingReplies() — connection dropped mid-wait
+		RCLCPP_ERROR(this->get_logger(), "ACK aborted for packet %d: %s", packet_id, e.what());
+		msg.result = 0xFF;
+	}
 
 	return msg;
+}
+
+/**
+ * @brief Fail all in-flight pending replies with an exception.
+ *
+ * Called on disconnect (error_event / end_event) so that any thread blocked in
+ * sendAndAwaitAck() or any other future.get() unblocks immediately.
+ */
+void Driver::failAllPendingReplies() {
+	auto ep = std::make_exception_ptr(std::runtime_error("Connection lost"));
+	std::lock_guard lock(pending_replies_mutex_);
+	for (auto& [id, reply] : pending_replies_) {
+		reply.on_cancel(ep);
+	}
+	pending_replies_.clear();
 }
 
 /**
@@ -1216,7 +1376,7 @@ adnav_interfaces::msg::RawAcknowledge Driver::AcknowledgeHandler() {
  * @return acknowledgement Message
  */
 adnav_interfaces::msg::RawAcknowledge Driver::SendPacketTimer(int packet_timer_period, bool utc_sync, bool permanent) {
-	RCLCPP_DEBUG_STREAM(this->get_logger(), "Incoming Packet Timer Request:\nUTC Sync: " <<
+	RCLCPP_DEBUG_STREAM(this->get_logger(), "Sending Packet Timer Request:\nUTC Sync: " <<
 		(utc_sync ? "True\n":"False\n") <<
 		"\tPermanent: " << (permanent ? "True\n":"False\n") <<
 		"\tPeriod (μs): " << packet_timer_period << "\n");
@@ -1233,13 +1393,10 @@ adnav_interfaces::msg::RawAcknowledge Driver::SendPacketTimer(int packet_timer_p
 	packet_timer_period_packet.utc_synchronisation = utc_sync;
 	packet_timer_period_packet.packet_timer_period = packet_timer_period;
 
-	// Send the packet.
+	// Send the packet and block until the device acknowledges or timeout.
 	RCLCPP_INFO(this->get_logger(), "Sending Packet Timer Request to device.");
 	an_packet = encode_packet_timer_period_packet(&packet_timer_period_packet);
-	encodeAndSend(an_packet);
-
-	// Return the acknowledgement result.
-	return AcknowledgeHandler();
+	return sendAndAwaitAck(an_packet);
 }
 
 /**
@@ -1253,7 +1410,7 @@ adnav_interfaces::msg::RawAcknowledge Driver::SendPacketTimer(int packet_timer_p
 adnav_interfaces::msg::RawAcknowledge Driver::SendPacketPeriods(const std::vector<adnav_interfaces::msg::PacketPeriod>& periods,
 	bool clear_existing, bool permanent) {
 	std::stringstream ss;
-	ss << "incoming Packet Request:\nClear: " << (clear_existing ? "True\n":"False\n") <<
+	ss << "Sending Packet Request:\nClear: " << (clear_existing ? "True\n":"False\n") <<
 		"Permanent: " << (permanent ? "True\n":"False\n") <<
 		"Number Requested: " << periods.size() << std::endl;
 
@@ -1280,9 +1437,7 @@ adnav_interfaces::msg::RawAcknowledge Driver::SendPacketPeriods(const std::vecto
 
 	RCLCPP_INFO(this->get_logger(), "Sending Packet Periods Request to device.");
 	an_packet = encode_packet_periods_packet(&packet_periods_packet);
-	encodeAndSend(an_packet);
-
-	return AcknowledgeHandler();
+	return sendAndAwaitAck(an_packet);
 }
 
 //~~~~~~ Decoders
@@ -1297,22 +1452,17 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 	// If there are bytes to be decoded.
 	an_packet_t* an_packet;
 	if (bytes > 0) {
-
-		anpp_logger_.writeAndIncrement(reinterpret_cast<char*>(an_decoder_pointer(&an_decoder)), bytes);
-		// Increment the decode buffer length by the number of bytes received
-		an_decoder_increment(&an_decoder, bytes);
-
 		// Decode all the packets in the buffer
+		std::unique_lock<std::mutex> lock(messages_mutex_);
+
 		while ((an_packet = an_packet_decode(&an_decoder)) != nullptr)
 		 {
-			RCLCPP_DEBUG(this->get_logger(), "ID: %d", an_packet->id);
+			RCLCPP_DEBUG(this->get_logger(), "RX Packet IDs %hhu", an_packet->id);
 
+			bool handled = true;
 			switch (an_packet->id)
 			 {
 			case packet_id_device_information: deviceInfoDecoder(an_packet);
-				break;
-
-			case packet_id_acknowledge: acknowledgeDecoder(an_packet);
 				break;
 
 			case packet_id_system_state: systemStateRosDecoder(an_packet);
@@ -1322,6 +1472,16 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 				break;
 
 			case packet_id_quaternion_orientation_standard_deviation: quartOrientSDRosDriver(an_packet);
+				break;
+
+			case packet_id_euler_orientation_standard_deviation:
+				euler_orientation_standard_deviation_packet_.emplace();
+				decode_euler_orientation_standard_deviation_packet(&*euler_orientation_standard_deviation_packet_, an_packet);
+				break;
+
+			case packet_id_velocity_standard_deviation:
+				velocity_standard_deviation_packet_.emplace();
+				decode_velocity_standard_deviation_packet(&*velocity_standard_deviation_packet_, an_packet);
 				break;
 
 			case packet_id_raw_sensors: rawSensorsRosDecoder(an_packet);
@@ -1336,39 +1496,34 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 				break;
 
 			default:
-				RCLCPP_WARN/*_THROTTLE*/(this->get_logger(), /* *this->get_clock(), 500, */
-					"Unsupported packet definition for ROS driver. PACKET_ID: %d", an_packet->id);
+				handled = false;
 				break;
 			}
+
+			// Generic pending reply dispatch — fires for any packet_id registered in pending_replies_.
+			// Runs alongside named case handlers, so both can fire for the same packet (e.g. device info
+			// is always decoded above AND can also satisfy a request-reply future registered below).
+			{
+				std::unique_lock reply_lock(pending_replies_mutex_);
+				auto it = pending_replies_.find(an_packet->id);
+				if (it != pending_replies_.end()) {
+					auto cb = std::move(it->second.on_packet);
+					pending_replies_.erase(it);
+					reply_lock.unlock();
+					cb(an_packet);
+					handled = true;
+				}
+			}
+
+			if (!handled) {
+				RCLCPP_WARN/*_THROTTLE*/(this->get_logger(), /* *this->get_clock(), 500, */
+					"Unsupported packet definition for ROS driver. PACKET_ID: %d", an_packet->id);
+			}
+
 			// Ensure that you free the an_packet when your done with it or you will leak memory
 			an_packet_free(&an_packet);
-		} // while an_packet != NULL
-	}// if bytes > 0
-}
-
-/**
- * @brief Function to decode a acknowledgement packet and notify relevant services.
- *
- * @param an_packet pointer to a an_packet_t object from which to decode the information.
- */
-void Driver::acknowledgeDecoder(an_packet_t* an_packet) {
-	// worker thread gets lock
-	std::unique_lock<std::mutex> lock(acknowledge_mutex_);
-
-	// Decode packet and warn if error.
-	if(decode_acknowledge_packet(&acknowledge_packet_, an_packet))
-	 {
-		RCLCPP_WARN(this->get_logger(), "Error decoding Acknowledge Packet");
+		}
 	}
-
-	RCLCPP_DEBUG(this->get_logger(), "acknowledgement received.\nID: %d\nResult: %d\n",
-		acknowledge_packet_.packet_id, acknowledge_packet_.acknowledge_result);
-
-	// Set the acknowledgement received to true
-	acknowledge_recieve_ = true;
-
-	// Notify the service thread
-	srv_cv_.notify_one();
 }
 
 /**
@@ -1443,10 +1598,6 @@ void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
 	const auto params = param_listener_->get_params();
 	system_state_packet_t system_state_packet;
 	std::stringstream ss;
-	std::unique_lock<std::mutex> lock(messages_mutex_);
-	RCLCPP_DEBUG(this->get_logger(), "Packet 20:\tMutex: L\tAccess: %d", P20_num_);
-	// Debug timekeeper
-	auto time = this->get_clock().get()->now().nanoseconds();
 
 	if(decode_system_state_packet(&system_state_packet, an_packet) == 0)
 	 {
@@ -1558,11 +1709,6 @@ void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
 				RCLCPP_INFO(this->get_logger(), "Event 1 Occurred.");
 			}
 	}
-	// Now that work is complete notify an update for the publisher.
-	msg_write_done_ = true;
-	msg_cv_.notify_one();
-	auto diff = this->get_clock().get()->now().nanoseconds() - time;
-	RCLCPP_DEBUG(this->get_logger(), "Packet 20:\tMutex: U\tAccess: %d\tTimeLocked: %ld μs", P20_num_++, diff/1000);
 }
 
 /**
@@ -1576,11 +1722,6 @@ void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
 void Driver::ecefPosRosDecoder(an_packet_t* an_packet) {
 	ecef_position_packet_t ecef_position_packet;
 
-	std::unique_lock<std::mutex> lock(messages_mutex_);
-	RCLCPP_DEBUG(this->get_logger(), "Packet 33:\tMutex: L\tAccess: %d", P33_num_);
-	// Debug timekeeper
-	auto time = this->get_clock().get()->now().nanoseconds();
-
 	// ECEF Position (in meters) Packet for Pose Message
 	if(decode_ecef_position_packet(&ecef_position_packet, an_packet) == 0)
 	 {
@@ -1588,12 +1729,6 @@ void Driver::ecefPosRosDecoder(an_packet_t* an_packet) {
 		pose_msg_.position.y = ecef_position_packet.position[1];
 		pose_msg_.position.z = ecef_position_packet.position[2];
 	}
-	// Now that work is complete notify an update for the publisher.
-	msg_write_done_ = true;
-	msg_cv_.notify_one();
-	// RCLCPP_DEBUG(this->get_logger(), "Raw: \tNotifying Complete\t%d", raw_num_++);
-	auto diff = this->get_clock().get()->now().nanoseconds() - time;
-	RCLCPP_DEBUG(this->get_logger(), "Packet 33:\tMutex: U\tAccess: %d\tTimeLocked: %ld μs", P33_num_++, diff/1000);
 }
 
 /**
@@ -1606,10 +1741,6 @@ void Driver::ecefPosRosDecoder(an_packet_t* an_packet) {
  */
 void Driver::quartOrientSDRosDriver(an_packet_t* an_packet) {
 	quaternion_orientation_standard_deviation_packet_t quaternion_orientation_standard_deviation_packet;
-	std::unique_lock<std::mutex> lock(messages_mutex_);
-	RCLCPP_DEBUG(this->get_logger(), "Packet 27: \tMutex: L\tAccess: %d", P27_num_);
-	// Debug timekeeper
-	auto time = this->get_clock().get()->now().nanoseconds();
 
 	if(decode_quaternion_orientation_standard_deviation_packet(&quaternion_orientation_standard_deviation_packet, an_packet) == 0)
 	 {
@@ -1618,12 +1749,6 @@ void Driver::quartOrientSDRosDriver(an_packet_t* an_packet) {
 		imu_msg_.orientation_covariance[4] = quaternion_orientation_standard_deviation_packet.standard_deviation[1];
 		imu_msg_.orientation_covariance[8] = quaternion_orientation_standard_deviation_packet.standard_deviation[2];
 	}
-	// Now that work is complete notify an update for the publisher.
-	msg_write_done_ = true;
-	msg_cv_.notify_one();
-	// RCLCPP_DEBUG(this->get_logger(), "Raw: \tNotifying Complete\t%d", raw_num_++);
-	auto diff = this->get_clock().get()->now().nanoseconds() - time;
-	RCLCPP_DEBUG(this->get_logger(), "Packet 27:\tMutex: U\tAccess: %d\tTimeLocked: %ld μs", P27_num_++, diff/1000);
 }
 
 /**
@@ -1636,12 +1761,6 @@ void Driver::quartOrientSDRosDriver(an_packet_t* an_packet) {
  */
 void Driver::rawSensorsRosDecoder(an_packet_t* an_packet) {
 	raw_sensors_packet_t raw_sensors_packet;
-
-	std::unique_lock<std::mutex> lock(messages_mutex_);
-
-	RCLCPP_DEBUG(this->get_logger(), "Packet 28: \tMutex: L\tAccess: %d", P28_num_);
-	// Debug timekeeper
-	auto time = this->get_clock().get()->now().nanoseconds();
 
 	// Fill the messages
 	if(decode_raw_sensors_packet(&raw_sensors_packet, an_packet) == 0) {
@@ -1670,20 +1789,12 @@ void Driver::rawSensorsRosDecoder(an_packet_t* an_packet) {
 		temp_msg_.temperature = raw_sensors_packet.pressure_temperature;
 
 	}
-	// Now that work is complete notify an update for the publisher.
-	msg_write_done_ = true;
-	msg_cv_.notify_one();
-	// RCLCPP_DEBUG(this->get_logger(), "Raw: \tNotifying Complete\t%d", raw_num_++);
-
-	auto diff = this->get_clock().get()->now().nanoseconds() - time;
-	RCLCPP_DEBUG(this->get_logger(), "Packet 28:\tMutex: U\tAccess: %d\tTimeLock: %ld μs", P28_num_++, diff/1000);
 }
 
 void Driver::bodyVelRosDecoder(an_packet_t *an_packet)
 {
 	body_velocity_packet_t body_velocity_packet;
-	std::unique_lock<std::mutex> lock(messages_mutex_);
-	// Debug timekeeper
+
 	auto stamp_time = this->get_clock().get()->now();
 
 	if (decode_body_velocity_packet(&body_velocity_packet, an_packet) == 0)
@@ -1695,16 +1806,11 @@ void Driver::bodyVelRosDecoder(an_packet_t *an_packet)
 		twist_stamped_msg_.header.frame_id = frame_id_;
 		twist_stamped_msg_.twist = twist_msg_;
 	}
-	// Now that work is complete notify an update for the publisher.
-	msg_write_done_ = true;
-	msg_cv_.notify_one();
 }
 
 void Driver::extBodyVelRosDecoder(an_packet_t *an_packet)
 {
 	external_body_velocity_packet_t external_body_velocity_packet;
-	std::unique_lock<std::mutex> lock(messages_mutex_);
-	// Debug timekeeper
 	auto stamp_time = this->get_clock().get()->now();
 
 	if (decode_external_body_velocity_packet(&external_body_velocity_packet, an_packet) == 0)
@@ -1715,8 +1821,6 @@ void Driver::extBodyVelRosDecoder(an_packet_t *an_packet)
 		twist_stamped_msg_external_body.header.stamp = stamp_time;
 		twist_stamped_msg_external_body.header.frame_id = external_frame_id_;
 	}
-	msg_write_done_ = true;
-	msg_cv_.notify_one();
 }
 
 }// namespace adnav

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -69,6 +69,7 @@ Driver::Driver(): rclcpp::Node("adnav_driver")
 	createPublishers();
 
 	system_state_packet_.set_lifespan(std::chrono::microseconds(params.publish_us * 3));
+	raw_sensors_packet_.set_lifespan(std::chrono::microseconds(params.publish_us * 3));
 	euler_orientation_standard_deviation_packet_.set_lifespan(std::chrono::microseconds(params.publish_us * 3));
 	velocity_standard_deviation_packet_.set_lifespan(std::chrono::microseconds(params.publish_us * 3));
 
@@ -77,7 +78,9 @@ Driver::Driver(): rclcpp::Node("adnav_driver")
 
 		while (!st.stop_requested()) {
 			const auto _params = param_listener_->get_params();
-			auto dest = uvw::socket_address{_params.ip_address, static_cast<unsigned int>(_params.port)};
+			auto resolver = loop->resource<uvw::get_addr_info_req>();
+
+			uvw::socket_address dest;
 
 			std::shared_ptr<uvw::tcp_handle> tcp_handle;
 			std::shared_ptr<uvw::udp_handle> udp_handle;
@@ -128,13 +131,13 @@ Driver::Driver(): rclcpp::Node("adnav_driver")
 			{
 				tcp_handle->on<uvw::error_event>([&](const uvw::error_event &err, uvw::tcp_handle &)
 				{
-					RCLCPP_ERROR(rclcpp::get_logger("adnav_driver"), "TCP: Connection Error: %s - stopping", err.what());
+					RCLCPP_ERROR(this->get_logger(), "TCP: Connection Error: %s - stopping", err.what());
 					failAllPendingReplies();
 					close_async_->send();
 				});
 
 				tcp_handle->on<uvw::end_event>([&](const uvw::end_event &, uvw::tcp_handle &) {
-					RCLCPP_INFO(rclcpp::get_logger("adnav_driver"), "TCP: End Event");
+					RCLCPP_INFO(this->get_logger(), "TCP: End Event");
 					failAllPendingReplies();
 					close_async_->send();
 				});
@@ -166,15 +169,25 @@ Driver::Driver(): rclcpp::Node("adnav_driver")
 					receivePackets(buffer);
 				});
 
-				RCLCPP_INFO(this->get_logger(), "TCP: Attempting to connect to %s:%ld", _params.ip_address.c_str(), _params.port);
-				tcp_handle->connect(dest);
+				auto resolved_addr = resolver->node_addr_info_sync(_params.ip_address.c_str());
+				if (!resolved_addr.first)
+				{
+					RCLCPP_ERROR(this->get_logger(), "Could not resolve hostname: %s.", _params.ip_address.c_str());
+					close_async_->send();
+				} else
+				{
+					dest = uvw::details::sock_addr(*resolved_addr.second->ai_addr);
+					dest.port = static_cast<unsigned int>(_params.port);
+					RCLCPP_INFO(this->get_logger(), "TCP: Attempting to connect to %s:%u", dest.ip.c_str(), dest.port);
+					tcp_handle->connect(dest);
+				}
 			}
 
 			if (udp_handle)
 			{
 				udp_handle->on<uvw::error_event>([&](const uvw::error_event &err, uvw::udp_handle &)
 				{
-					RCLCPP_ERROR(rclcpp::get_logger("adnav_driver"), "UDP: Connection Error: %s - stopping", err.what());
+					RCLCPP_ERROR(this->get_logger(), "UDP: Connection Error: %s - stopping", err.what());
 					failAllPendingReplies();
 					close_async_->send();
 				});
@@ -186,31 +199,42 @@ Driver::Driver(): rclcpp::Node("adnav_driver")
 					receivePackets(buffer);
 				});
 
-				// determine the correct local address to listen on
-				udp_handle->connect(dest);
-				auto local_addr = udp_handle->sock();
-				local_addr.port = static_cast<unsigned int>(_params.port);
-				udp_handle->disconnect();
+				auto resolved_addr = resolver->node_addr_info_sync(_params.ip_address.c_str());
+				if (!resolved_addr.first)
+				{
+					RCLCPP_ERROR(this->get_logger(), "Could not resolve hostname: %s.", _params.ip_address.c_str());
+					close_async_->send();
+				} else
+				{
+					dest = uvw::details::sock_addr(*resolved_addr.second->ai_addr);
+					dest.port = static_cast<unsigned int>(_params.port);
 
-				udp_handle->bind(local_addr);
-				udp_handle->recv();
+					// determine the correct local address to listen on
+					udp_handle->connect(dest);
+					auto local_addr = udp_handle->sock();
+					local_addr.port = static_cast<unsigned int>(_params.port);
+					udp_handle->disconnect();
 
-				RCLCPP_INFO(this->get_logger(), "UDP: Created %s:%u --> endpoint %s:%u", local_addr.ip.c_str(), local_addr.port,
-					dest.ip.c_str(), dest.port);
+					udp_handle->bind(local_addr);
+					udp_handle->recv();
 
-				// Run setup in a separate thread so it can block on request-reply futures
-				// without stalling the event loop. join() is fast — failAllPendingReplies() will
-				// have unblocked any in-flight future before we reach here on reconnect.
-				if (setup_thread_.joinable()) setup_thread_.join();
-				setup_thread_ = std::jthread([this] {
-					if (!requestDeviceInfo())
-					{
-						RCLCPP_ERROR(rclcpp::get_logger("adnav_driver"), "Did not get a Device Information reply - stopping");
-						close_async_->send();
-						return;
-					}
-					deviceSetup();
-				});
+					RCLCPP_INFO(this->get_logger(), "UDP: Created %s:%u --> endpoint %s:%u", local_addr.ip.c_str(), local_addr.port,
+						dest.ip.c_str(), dest.port);
+
+					// Run setup in a separate thread so it can block on request-reply futures
+					// without stalling the event loop. join() is fast — failAllPendingReplies() will
+					// have unblocked any in-flight future before we reach here on reconnect.
+					if (setup_thread_.joinable()) setup_thread_.join();
+					setup_thread_ = std::jthread([this] {
+						if (!requestDeviceInfo())
+						{
+							RCLCPP_ERROR(this->get_logger(), "Did not get a Device Information reply - stopping");
+							close_async_->send();
+							return;
+						}
+						deviceSetup();
+					});
+				}
 			}
 
 			loop->run();
@@ -272,18 +296,28 @@ Driver::~Driver() {
 	connection_thread_.join();
 }
 
-rclcpp::Time time_from_state_packet(const system_state_packet_t& state_packet) {
-	// Create a ROS time from the system state packet timestamp
-	auto sec = state_packet.unix_time_seconds;
-	auto nanosecs = state_packet.microseconds * 1000;
+rclcpp::Time time_from_seconds_microseconds(uint32_t seconds, uint32_t microseconds) {
+	auto nanosecs = microseconds * 1000;
 
 	// Handle possible rollover of nanoseconds
 	if (nanosecs >= 1000000000) {
-		sec += nanosecs / 1000000000;
+		seconds += nanosecs / 1000000000;
 		nanosecs = nanosecs % 1000000000;
 	}
 
-	return {static_cast<int32_t>(sec), nanosecs, RCL_ROS_TIME};
+	return {static_cast<int32_t>(seconds), nanosecs, RCL_ROS_TIME};
+}
+
+rclcpp::Duration duration_from_seconds_microseconds(uint32_t seconds, uint32_t microseconds) {
+	auto nanosecs = microseconds * 1000;
+
+	// Handle possible rollover of nanoseconds
+	if (nanosecs >= 1000000000) {
+		seconds += nanosecs / 1000000000;
+		nanosecs = nanosecs % 1000000000;
+	}
+
+	return {static_cast<int32_t>(seconds), nanosecs};
 }
 
 /**
@@ -336,20 +370,34 @@ bool Driver::requestDeviceInfo() {
  * @brief Function to declare topics and publishers for the adnav_driver node.
  */
 void Driver::createPublishers() {
-	// Creating the ROS2 Publishers
-	imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu", 10);
-	imu_raw_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_raw", 10);
+	const auto params = param_listener_->get_params();
+
+	// Following packets are derived from system state
 	nav_sat_fix_pub_ = this->create_publisher<sensor_msgs::msg::NavSatFix>("nav_sat_fix", 10);
-	magnetic_field_pub_ = this->create_publisher<sensor_msgs::msg::MagneticField>("magnetic_field", 10);
-	barometric_pressure_pub_ = this->create_publisher<sensor_msgs::msg::FluidPressure>("barometric_pressure", 10);
-	temperature_pub_ = this->create_publisher<sensor_msgs::msg::Temperature>("temperature", 10);
 	twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("twist", 10);
 	twist_stamped_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("twist_stamped", 10);
-	twist_stamped_external_body_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("twist_stamped_external_body", 10);
-	pose_pub_ = this->create_publisher<geometry_msgs::msg::Pose>("pose", 10);
-	pose_stamped_pub_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("pose_stamped", 10);
 	geo_pose_pub_ = this->create_publisher<geographic_msgs::msg::GeoPose>("geopose", 10);
 	geo_pose_stamped_pub_ = this->create_publisher<geographic_msgs::msg::GeoPoseStamped>("geopose_stamped", 10);
+	imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu", 10);
+
+	if (params.additional_packets.raw_sensors)
+	{
+		imu_raw_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_raw", 10);
+		magnetic_field_pub_ = this->create_publisher<sensor_msgs::msg::MagneticField>("magnetic_field", 10);
+		barometric_pressure_pub_ = this->create_publisher<sensor_msgs::msg::FluidPressure>("barometric_pressure", 10);
+		temperature_pub_ = this->create_publisher<sensor_msgs::msg::Temperature>("temperature", 10);
+	}
+
+	if (params.additional_packets.external_body_velocity)
+	{
+		twist_stamped_external_body_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("twist_stamped_external_body", 10);
+	}
+
+	if (params.additional_packets.ecef_position)
+	{
+		pose_pub_ = this->create_publisher<geometry_msgs::msg::Pose>("pose", 10);
+		pose_stamped_pub_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("pose_stamped", 10);
+	}
 }
 
 /**
@@ -443,6 +491,18 @@ void Driver::receivePackets(const std::span<const uint8_t> buffer) {
 	decodePackets(an_decoder, buffer_bytes);
 }
 
+	bool Driver::packet_is_recent(uint8_t packet_id, std::chrono::microseconds max_age) {
+		auto now = this->get_clock()->now();
+		auto pkt_it = packet_receive_times.find(packet_id);
+		if (pkt_it == packet_receive_times.end())
+		{
+			return false;
+		}
+		auto packet_time = pkt_it->second;
+
+		return now - packet_time <= rclcpp::Duration(max_age);
+	}
+
 /**
  * @brief Periodic callback for publishing ROS messages.
  *
@@ -457,21 +517,36 @@ void Driver::publishTimerCallback() {
 
 	// Since the messages can be filled in other threads ensure exclusive access.
 	std::unique_lock<std::mutex> lock(messages_mutex_);
+	const auto params = param_listener_->get_params();
 
-	// PUBLISH MESSAGES
-	nav_sat_fix_pub_->publish(nav_fix_msg_);
-	twist_pub_->publish(twist_msg_);
-	twist_stamped_pub_->publish(twist_stamped_msg_);
-	twist_stamped_external_body_pub_->publish(twist_stamped_msg_external_body);
-	imu_pub_->publish(imu_msg_);
-	imu_raw_pub_->publish(imu_raw_msg_);
-	magnetic_field_pub_->publish(mag_field_msg_);
-	barometric_pressure_pub_->publish(baro_msg_);
-	temperature_pub_->publish(temp_msg_);
-	pose_pub_->publish(pose_msg_);
-	pose_stamped_pub_->publish(pose_stamped_msg_);
-	geo_pose_pub_->publish(geo_pose_msg_);
-	geo_pose_stamped_pub_->publish(geo_pose_stamped_msg_);
+	if (packet_is_recent(packet_id_system_state, std::chrono::microseconds(params.publish_us)))
+	{
+		nav_sat_fix_pub_->publish(nav_fix_msg_);
+		twist_pub_->publish(twist_msg_);
+		twist_stamped_pub_->publish(twist_stamped_msg_);
+		imu_pub_->publish(imu_msg_);
+		geo_pose_pub_->publish(geo_pose_msg_);
+		geo_pose_stamped_pub_->publish(geo_pose_stamped_msg_);
+	}
+
+	if (packet_is_recent(packet_id_external_body_velocity, std::chrono::microseconds(params.publish_us)) && twist_stamped_external_body_pub_)
+	{
+		twist_stamped_external_body_pub_->publish(twist_stamped_msg_external_body);
+	}
+
+	if (packet_is_recent(packet_id_raw_sensors, std::chrono::microseconds(params.publish_us)) && imu_raw_pub_ && magnetic_field_pub_ && barometric_pressure_pub_ && temperature_pub_)
+	{
+		imu_raw_pub_->publish(imu_raw_msg_);
+		magnetic_field_pub_->publish(mag_field_msg_);
+		barometric_pressure_pub_->publish(baro_msg_);
+		temperature_pub_->publish(temp_msg_);
+	}
+
+	if (packet_is_recent(packet_id_ecef_position, std::chrono::microseconds(params.publish_us)) && pose_pub_ && pose_stamped_pub_)
+	{
+		pose_pub_->publish(pose_msg_);
+		pose_stamped_pub_->publish(pose_stamped_msg_);
+	}
 }
 
 /**
@@ -699,9 +774,9 @@ void Driver::accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &st
 		const auto gnss_fix = static_cast<GnssFixStatus>(sys_state_pkt->filter_status.b.gnss_fix_type);
 		stat.add("GNSS Fix Status", to_string(gnss_fix));
 
-		if (params.health.gnss_fix && gnss_fix != GnssFixStatus::Fix3D)
+		if (params.health.gnss_fix && (gnss_fix == GnssFixStatus::NoFix || gnss_fix == GnssFixStatus::Fix2D))
 		{
-			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No GNSS 3D Fix");
+			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No precise GNSS Fix");
 		}
 
 		if (params.health.external_velocity)
@@ -1108,10 +1183,24 @@ std::vector<adnav_interfaces::msg::PacketPeriod> Driver::getPacketRequest() {
 			packet_periods.push_back(period);
 		}
 
-		for (std::size_t i = 0; (i+i) < params.additional_packet_request.size(); i++) {
+		if (params.additional_packets.external_body_velocity) {
 			adnav_interfaces::msg::PacketPeriod period;
-			period.packet_id = params.additional_packet_request[i+i];
-			period.packet_period = params.additional_packet_request[i+i+1];
+			period.packet_id = packet_id_external_body_velocity;
+			period.packet_period = params.default_packet_period;
+			packet_periods.push_back(period);
+		}
+
+		if (params.additional_packets.ecef_position) {
+			adnav_interfaces::msg::PacketPeriod period;
+			period.packet_id = packet_id_ecef_position;
+			period.packet_period = params.default_packet_period;
+			packet_periods.push_back(period);
+		}
+
+		if (params.additional_packets.raw_sensors) {
+			adnav_interfaces::msg::PacketPeriod period;
+			period.packet_id = packet_id_raw_sensors;
+			period.packet_period = params.default_packet_period;
 			packet_periods.push_back(period);
 		}
 	}
@@ -1512,20 +1601,25 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 			case packet_id_euler_orientation_standard_deviation:
 				{
 					euler_orientation_standard_deviation_packet_t pkt;
-					decode_euler_orientation_standard_deviation_packet(&pkt, an_packet);
-					euler_orientation_standard_deviation_packet_ = pkt;
+					if (decode_euler_orientation_standard_deviation_packet(&pkt, an_packet) == 0)
+					{
+						euler_orientation_standard_deviation_packet_ = pkt;
+					}
 					break;
 				}
 
 			case packet_id_velocity_standard_deviation:
 				{
 					velocity_standard_deviation_packet_t pkt;
-					decode_velocity_standard_deviation_packet(&pkt, an_packet);
-					velocity_standard_deviation_packet_ = pkt;
+					if (decode_velocity_standard_deviation_packet(&pkt, an_packet) == 0)
+					{
+						velocity_standard_deviation_packet_ = pkt;
+					}
 					break;
 				}
 
-			case packet_id_raw_sensors: rawSensorsRosDecoder(an_packet);
+			case packet_id_raw_sensors:
+				rawSensorsRosDecoder(an_packet);
 				break;
 
 			case packet_id_body_velocity:
@@ -1536,6 +1630,22 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 				extBodyVelRosDecoder(an_packet);
 				break;
 
+			case packet_id_running_time:
+				{
+					running_time_packet_t pkt;
+					if (decode_running_time_packet(&pkt, an_packet) == 0)
+					{
+						auto uptime = duration_from_seconds_microseconds(pkt.seconds, pkt.microseconds);
+						if (device_running_time_ && uptime < *device_running_time_)
+						{
+							RCLCPP_ERROR(this->get_logger(), "Device running time has gone backwards. Previous: %f seconds, Current: %f seconds. This may indicate a device reset or clock issue.",
+								device_running_time_->seconds(), uptime.seconds());
+							close_async_->send();
+						}
+						device_running_time_ = uptime;
+					}
+					break;
+				}
 			default:
 				handled = false;
 				break;
@@ -1588,16 +1698,16 @@ void Driver::deviceInfoDecoder(an_packet_t* an_packet) {
 		diagnostic_updater_->setHardwareID(serial_num.str());
 		device_information_packet_ = device_information_packet;
 	}
+
 	// since multiple packets may be requested before the device responds. ensure only one gets printed per second.
-	RCLCPP_INFO_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "Device Information:\n"
-			<< "Device ID: " <<	device_information_packet.device_id <<
-			"\nVersion:" <<
-			"\n  Software: " << device_information_packet.software_version <<
-			"\n  Hardware: " << device_information_packet.hardware_revision <<
-			"\nSerial Number: " << std::hex << device_information_packet.serial_number[0] <<
-				device_information_packet.serial_number[1] << device_information_packet.serial_number[2]
-			<< std::endl
-			);
+	RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "%s",
+		std::format("Device ID: {} - Software Rev: {} - Hardware Rev: {} - Serial Number: {:X}{:X}{:X}",
+			device_information_packet.device_id,
+			device_information_packet.software_version,
+			device_information_packet.hardware_revision,
+			device_information_packet.serial_number[0],
+			device_information_packet.serial_number[1],
+			device_information_packet.serial_number[2]).c_str());
 }
 
         geometry_msgs::msg::Twist transformTwistEnuToFlu(
@@ -1645,7 +1755,8 @@ void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
 	if(decode_system_state_packet(&system_state_packet, an_packet) == 0)
 	 {
 			// NAVSATFIX
-			nav_fix_msg_.header.stamp = time_from_state_packet(system_state_packet);
+			nav_fix_msg_.header.stamp = time_from_seconds_microseconds(system_state_packet.unix_time_seconds,
+				system_state_packet.microseconds);
 			nav_fix_msg_.header.frame_id = frame_id_;
 			if ((system_state_packet.filter_status.b.gnss_fix_type == gnss_fix_2d) ||
 				(system_state_packet.filter_status.b.gnss_fix_type == gnss_fix_3d))
@@ -1807,7 +1918,7 @@ void Driver::rawSensorsRosDecoder(an_packet_t* an_packet) {
 
 	// Fill the messages
 	if(decode_raw_sensors_packet(&raw_sensors_packet, an_packet) == 0) {
-
+		raw_sensors_packet_ = raw_sensors_packet;
 		// RAW MAGNETICFIELD VALUE FROM IMU
 		mag_field_msg_.header.frame_id = frame_id_;
 		mag_field_msg_.magnetic_field.x = raw_sensors_packet.magnetometers[0];
@@ -1830,7 +1941,6 @@ void Driver::rawSensorsRosDecoder(an_packet_t* an_packet) {
 		// TEMPERATURE
 		temp_msg_.header.frame_id = frame_id_;
 		temp_msg_.temperature = raw_sensors_packet.pressure_temperature;
-
 	}
 }
 

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -150,12 +150,12 @@ void Driver::waitForDevicePacket() {
 		// Decode all data and act on only the device info data.
 		if (bytes_received > 0)
 		 {
-			anpp_logger_.writeAndIncrement((char*) an_decoder_pointer(&an_decoder), bytes_received);
+			anpp_logger_.writeAndIncrement(reinterpret_cast<char*>(an_decoder_pointer(&an_decoder)), bytes_received);
 
 			// Increment the decode buffer length by the number of bytes received
 			an_decoder_increment(&an_decoder, bytes_received);
 
-			while ((an_packet = an_packet_decode(&an_decoder)) != NULL)
+			while ((an_packet = an_packet_decode(&an_decoder)) != nullptr)
 			 {
 				RCLCPP_DEBUG(this->get_logger(), "[WaitForDevicePacket]ID: %d", an_packet->id);
 
@@ -196,6 +196,7 @@ void Driver::createPublishers() {
 	temperature_pub_ = this->create_publisher<sensor_msgs::msg::Temperature>("~/temperature", 10);
 	twist_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("~/twist", 10);
 	twist_stamped_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("~/twist_stamped", 10);
+	twist_stamped_external_body_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("~/twist_stamped_external_body", 10);
 	pose_pub_ = this->create_publisher<geometry_msgs::msg::Pose>("~/pose", 10);
 	pose_stamped_pub_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("~/pose_stamped", 10);
 	geo_pose_pub_ = this->create_publisher<geographic_msgs::msg::GeoPose>("~/geopose", 10);
@@ -582,6 +583,7 @@ void Driver::publishTimerCallback() {
 	nav_sat_fix_pub_->publish(nav_fix_msg_);
 	twist_pub_->publish(twist_msg_);
 	twist_stamped_pub_->publish(twist_stamped_msg_);
+	twist_stamped_external_body_pub_->publish(twist_stamped_msg_external_body);
 	imu_pub_->publish(imu_msg_);
 	imu_raw_pub_->publish(imu_raw_msg_);
 	magnetic_field_pub_->publish(mag_field_msg_);
@@ -1604,6 +1606,14 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 			case packet_id_raw_sensors: rawSensorsRosDecoder(an_packet);
 				break;
 
+			case packet_id_body_velocity:
+				bodyVelRosDecoder(an_packet);
+				break;
+
+			case packet_id_external_body_velocity:
+				extBodyVelRosDecoder(an_packet);
+				break;
+
 			default:
 				RCLCPP_WARN/*_THROTTLE*/(this->get_logger(), /* *this->get_clock(), 500, */
 					"Unsupported packet definition for ROS driver. PACKET_ID: %d", an_packet->id);
@@ -1943,4 +1953,45 @@ void Driver::rawSensorsRosDecoder(an_packet_t* an_packet) {
 	auto diff = this->get_clock().get()->now().nanoseconds() - time;
 	RCLCPP_DEBUG(this->get_logger(), "Packet 28:\tMutex: U\tAccess: %d\tTimeLock: %ld μs", P28_num_++, diff/1000);
 }
+
+void Driver::bodyVelRosDecoder(an_packet_t *an_packet)
+{
+	body_velocity_packet_t body_velocity_packet;
+	std::unique_lock<std::mutex> lock(messages_mutex_);
+	// Debug timekeeper
+	auto stamp_time = this->get_clock().get()->now();
+
+	if (decode_body_velocity_packet(&body_velocity_packet, an_packet) == 0)
+	{
+		twist_msg_.linear.x = body_velocity_packet.velocity[0];
+		twist_msg_.linear.y = -body_velocity_packet.velocity[1];
+		twist_msg_.linear.z = -body_velocity_packet.velocity[2];
+		twist_stamped_msg_.header.stamp = stamp_time;
+		twist_stamped_msg_.header.frame_id = frame_id_;
+		twist_stamped_msg_.twist = twist_msg_;
+	}
+	// Now that work is complete notify an update for the publisher.
+	msg_write_done_ = true;
+	msg_cv_.notify_one();
+}
+
+void Driver::extBodyVelRosDecoder(an_packet_t *an_packet)
+{
+	external_body_velocity_packet_t external_body_velocity_packet;
+	std::unique_lock<std::mutex> lock(messages_mutex_);
+	// Debug timekeeper
+	auto stamp_time = this->get_clock().get()->now();
+
+	if (decode_external_body_velocity_packet(&external_body_velocity_packet, an_packet) == 0)
+	{
+		twist_stamped_msg_external_body.twist.linear.x = external_body_velocity_packet.velocity[0];
+		twist_stamped_msg_external_body.twist.linear.y = -external_body_velocity_packet.velocity[1];
+		twist_stamped_msg_external_body.twist.linear.z = -external_body_velocity_packet.velocity[2];
+		twist_stamped_msg_external_body.header.stamp = stamp_time;
+		twist_stamped_msg_external_body.header.frame_id = external_frame_id_;
+	}
+	msg_write_done_ = true;
+	msg_cv_.notify_one();
+}
+
 }// namespace adnav

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -388,6 +388,11 @@ void Driver::createPublishers() {
 		temperature_pub_ = this->create_publisher<sensor_msgs::msg::Temperature>("temperature", 10);
 	}
 
+	if (params.additional_packets.body_velocity)
+	{
+		twist_stamped_body_velocity_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("twist_stamped_body", 10);
+	}
+
 	if (params.additional_packets.external_body_velocity)
 	{
 		twist_stamped_external_body_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>("twist_stamped_external_body", 10);
@@ -527,6 +532,11 @@ void Driver::publishTimerCallback() {
 		imu_pub_->publish(imu_msg_);
 		geo_pose_pub_->publish(geo_pose_msg_);
 		geo_pose_stamped_pub_->publish(geo_pose_stamped_msg_);
+	}
+
+	if (packet_is_recent(packet_id_body_velocity, std::chrono::microseconds(params.publish_us)) && twist_stamped_body_velocity_pub_)
+	{
+		twist_stamped_body_velocity_pub_->publish(twist_stamped_msg_body);
 	}
 
 	if (packet_is_recent(packet_id_external_body_velocity, std::chrono::microseconds(params.publish_us)) && twist_stamped_external_body_pub_)
@@ -1183,6 +1193,13 @@ std::vector<adnav_interfaces::msg::PacketPeriod> Driver::getPacketRequest() {
 			packet_periods.push_back(period);
 		}
 
+		if (params.additional_packets.body_velocity) {
+			adnav_interfaces::msg::PacketPeriod period;
+			period.packet_id = packet_id_body_velocity;
+			period.packet_period = params.default_packet_period;
+			packet_periods.push_back(period);
+		}
+
 		if (params.additional_packets.external_body_velocity) {
 			adnav_interfaces::msg::PacketPeriod period;
 			period.packet_id = packet_id_external_body_velocity;
@@ -1807,16 +1824,14 @@ void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
 
 			// TWIST
 
-			if (!params.use_body_velocity)
-			{
-				twist_msg_.linear.x = system_state_packet.velocity[0];
-				twist_msg_.linear.y = system_state_packet.velocity[1];
-				twist_msg_.linear.z = system_state_packet.velocity[2];
+			twist_msg_.linear.x = system_state_packet.velocity[0];
+			twist_msg_.linear.y = system_state_packet.velocity[1];
+			twist_msg_.linear.z = system_state_packet.velocity[2];
 
-				if (params.convert_twist_enu_to_flu) {
-					twist_msg_ = transformTwistEnuToFlu(twist_msg_, orientation_);
-				}
+			if (params.convert_twist_enu_to_flu) {
+				twist_msg_ = transformTwistEnuToFlu(twist_msg_, orientation_);
 			}
+
 			twist_msg_.angular.x = system_state_packet.angular_velocity[0];
 			twist_msg_.angular.y = system_state_packet.angular_velocity[1];
 			twist_msg_.angular.z = system_state_packet.angular_velocity[2];
@@ -1826,16 +1841,10 @@ void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
 
 			// IMU
 			imu_msg_.header = nav_fix_msg_.header;
-
 			imu_msg_.orientation.x = orientation_[0];
 			imu_msg_.orientation.y = orientation_[1];
 			imu_msg_.orientation.z = orientation_[2];
 			imu_msg_.orientation.w = orientation_[3];
-
-			// POSE Orientation
-			pose_msg_.orientation = imu_msg_.orientation;
-			pose_stamped_msg_.pose = pose_msg_;
-			pose_stamped_msg_.header = nav_fix_msg_.header;
 
 			imu_msg_.angular_velocity.x = system_state_packet.angular_velocity[0]; // These the same as the TWIST msg values
 			imu_msg_.angular_velocity.y = system_state_packet.angular_velocity[1];
@@ -1882,6 +1891,11 @@ void Driver::ecefPosRosDecoder(an_packet_t* an_packet) {
 		pose_msg_.position.x = ecef_position_packet.position[0];
 		pose_msg_.position.y = ecef_position_packet.position[1];
 		pose_msg_.position.z = ecef_position_packet.position[2];
+
+		// TODO this borrowing between packets isn't great
+		pose_msg_.orientation = imu_msg_.orientation;
+		pose_stamped_msg_.pose = pose_msg_;
+		pose_stamped_msg_.header = nav_fix_msg_.header;
 	}
 }
 
@@ -1948,23 +1962,30 @@ void Driver::bodyVelRosDecoder(an_packet_t *an_packet)
 {
 	body_velocity_packet_t body_velocity_packet;
 
-	auto stamp_time = this->get_clock().get()->now();
+	const auto stamp_time = this->get_clock().get()->now();
 
 	if (decode_body_velocity_packet(&body_velocity_packet, an_packet) == 0)
 	{
-		twist_msg_.linear.x = body_velocity_packet.velocity[0];
-		twist_msg_.linear.y = -body_velocity_packet.velocity[1];
-		twist_msg_.linear.z = -body_velocity_packet.velocity[2];
-		twist_stamped_msg_.header.stamp = stamp_time;
-		twist_stamped_msg_.header.frame_id = frame_id_;
-		twist_stamped_msg_.twist = twist_msg_;
+		twist_stamped_msg_body.twist.linear.x = body_velocity_packet.velocity[0];
+		twist_stamped_msg_body.twist.linear.y = -body_velocity_packet.velocity[1];
+		twist_stamped_msg_body.twist.linear.z = -body_velocity_packet.velocity[2];
+
+		if (const auto sys_pkt = system_state_packet_.value(); sys_pkt.has_value())
+		{
+			// borrow the angular rates from the system packet
+			twist_stamped_msg_body.twist.angular.x = sys_pkt.value().angular_velocity[0];
+			twist_stamped_msg_body.twist.angular.y = sys_pkt.value().angular_velocity[1];
+			twist_stamped_msg_body.twist.angular.z = sys_pkt.value().angular_velocity[2];
+		}
+		twist_stamped_msg_body.header.stamp = stamp_time;
+		twist_stamped_msg_body.header.frame_id = frame_id_;
 	}
 }
 
 void Driver::extBodyVelRosDecoder(an_packet_t *an_packet)
 {
 	external_body_velocity_packet_t external_body_velocity_packet;
-	auto stamp_time = this->get_clock().get()->now();
+	const auto stamp_time = this->get_clock().get()->now();
 
 	if (decode_external_body_velocity_packet(&external_body_velocity_packet, an_packet) == 0)
 	{

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -55,23 +55,34 @@ Driver::Driver(): rclcpp::Node("adnav_driver"), msg_write_done_(false)
 	diagnostic_updater_ = std::make_shared<diagnostic_updater::Updater>(this);
 
 	// Setup parameters for the node
+	param_listener_ = std::make_shared<adnav::ParamListener>(this);
 	setupParamService();
 
 	// Create timers for callbacks
+	const auto params = param_listener_->get_params();
+	// Reset the timer using the class stored interval.
 	publish_timer_ = this->create_wall_timer(
-      	publish_timer_interval_ , std::bind(&Driver::publishTimerCallback, this), publishing_group_);
+		std::chrono::microseconds(params.publish_us), std::bind(&Driver::publishTimerCallback, this),
+		publishing_group_);
 
 	read_timer_ = this->create_wall_timer(
-		read_timer_interval_, std::bind(&Driver::recievePackets, this), reading_group_);
+		std::chrono::microseconds(params.read_us), std::bind(&Driver::recievePackets, this), reading_group_);
 
 	// Setup Services for the node
 	createServices();
 
 	// Open a new ANPP Log file for data logging
-	anpp_logger_.openFile("Log_", ".anpp", log_path_);
+	anpp_logger_.openFile("Log_", ".anpp", params.log_path);
 
 	// Open Communications with the device
-	communicator_ = std::make_unique<adnav::Communicator>(comms_data_);
+
+	adnav_connections_data_t comms_data {};
+	comms_data.method = params.comm_select;
+	comms_data.com_port = params.com_port;
+	comms_data.ip_address = params.ip_address;
+	comms_data.port = params.port;
+
+	communicator_ = std::make_unique<adnav::Communicator>(comms_data);
 	communicator_->open();
 
 	// Request device info with Packet 1 and 3
@@ -86,7 +97,7 @@ Driver::Driver(): rclcpp::Node("adnav_driver"), msg_write_done_(false)
 	diagnostic_updater_->add("System Status", this, &Driver::system_status_diagnostic);
 	diagnostic_updater_->add("Filter Status", this, &Driver::filter_status_diagnostic);
 
-	RCLCPP_INFO(this->get_logger(), "Your Advanced Navigation ROS driver is currently running\nPress Ctrl-C to interrupt\n");
+	RCLCPP_DEBUG(this->get_logger(), "Your Advanced Navigation ROS driver is currently running\nPress Ctrl-C to interrupt\n");
 }
 
 /**
@@ -95,7 +106,7 @@ Driver::Driver(): rclcpp::Node("adnav_driver"), msg_write_done_(false)
  * Closes the Logfiles and gives name to the user. Shutsdown the communication method
  */
 Driver::~Driver() {
-	RCLCPP_INFO(this->get_logger(), "Deconstructing Adnav_Driver node");
+	RCLCPP_DEBUG(this->get_logger(), "Deconstructing Adnav_Driver node");
 
 	anpp_logger_.closeFile();
 
@@ -228,31 +239,18 @@ void Driver::createServices() {
 		service_group_);
 }
 
-/**
- * @brief Method to push requested configuration to the device.
- *
- * This method will take stored data on the configurationand form configuration packets which
- * will then be pushed to the device.
- */
 void Driver::deviceSetup() {
 	RCLCPP_INFO(this->get_logger(), "Sending requested configuration to device:");
 
+	const auto params = param_listener_->get_params();
+
 	// Create and send a Packet Timer Period Packet.
 	acknowledge_recieve_ = true; // Since we are not waiting for device acknowledgement at startup
-	(void)SendPacketTimer(packet_timer_period_); // Will overwrite acknowledge_receive_ to false
-
-	// Create and fill a periods format.
-	std::vector<adnav_interfaces::msg::PacketPeriod> packet_periods;
-	for(uint64_t i = 0; (i+i) < packet_request_.size(); i++) {
-		adnav_interfaces::msg::PacketPeriod period;
-		period.packet_id = packet_request_[i+i];
-		period.packet_period = packet_request_[i+i+1];
-		packet_periods.push_back(period);
-	}
+	SendPacketTimer(params.packet_timer_period); // Will overwrite acknowledge_receive_ to false
 
 	// Since we are not waiting for device acknowledgement at startup
 	acknowledge_recieve_ = true;
-	(void)SendPacketPeriods(packet_periods); // Will overwrite acknowledge_receive_ to false.
+	SendPacketPeriods(getPacketRequest()); // Will overwrite acknowledge_receive_ to false.
 }
 
 /**
@@ -263,10 +261,6 @@ void Driver::deviceSetup() {
  * Will assign a default value if one is not provided already.
  */
 void Driver::setupParamService() {
-
-	// Setup and validate launch parameters.
-	setupParams();
-
 	// Register the callback for parameter changes.
 	// Will be called whenever a parameter is update is requested.
 	param_set_cb_ = this->add_on_set_parameters_callback(
@@ -299,214 +293,6 @@ void Driver::setupParamService() {
 			std::bind(&Driver::updatePacketTimer,
 					this,
 					std::placeholders::_1));
-}
-
-/**
- * @brief Method to setup node parameters.
- *
- * This method will declare, describe, and assign values to node parameters
- * Will assign a default value if one is not provided already, or a provided value fails verification.
- */
-void Driver::setupParams() {
-	std::stringstream ss;
-
-	// Baud Rate - Read only
-	rcl_interfaces::msg::ParameterDescriptor baud_description = rcl_interfaces::msg::ParameterDescriptor();
-	ss << 	"Baud rate for communication with AdvancedNavigation Device\n" <<
-			"Default: " << DEFAULT_BAUD_RATE;
-	baud_description.description = ss.str();
-	ss.str(""); // empty the stream
-	baud_description.name = "baud_rate";
-	baud_description.read_only = true;
-	baud_description.additional_constraints = "\n\tSupported Baud Rates:\n\t  2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 576000, 921600, 1000000, 2000000";
-	this->declare_parameter<int>("baud_rate", DEFAULT_BAUD_RATE, baud_description);
-	if( validateBaudRate( this->get_parameter("baud_rate") ).successful ) { // Check that it is valid and save
-		comms_data_.baud_rate = (int) this->get_parameter("baud_rate").as_int();
-	}else {// If invalid save default.
-		RCLCPP_ERROR(this->get_logger(), "Invalid baud rate. Setting to default: %d", DEFAULT_BAUD_RATE);
-		this->set_parameter(rclcpp::Parameter("baud_rate", DEFAULT_BAUD_RATE));
-		comms_data_.baud_rate = DEFAULT_BAUD_RATE;
-	}
-
-	// Com_port - Read only
-	rcl_interfaces::msg::ParameterDescriptor com_port_description = rcl_interfaces::msg::ParameterDescriptor();
-	com_port_description.description = "Communications port for serial operation\n  Default: \"/dev/ttyUSB0\"";
-	com_port_description.name = "com_port";
-	com_port_description.read_only = true;
-	this->declare_parameter<std::string>("com_port", DEFAULT_COM_PORT, com_port_description);
-	if( validateComPort( this->get_parameter("com_port") ).successful ) { // Check that it is valid and save
-		comms_data_.com_port = this->get_parameter("com_port").as_string();
-	}else { // If invalid save default.
-		RCLCPP_ERROR(this->get_logger(), "Invalid com port. Setting to default: %s", DEFAULT_COM_PORT);
-		this->set_parameter(rclcpp::Parameter("com_port", DEFAULT_COM_PORT));
-		comms_data_.com_port = DEFAULT_COM_PORT;
-	}
-
-	rcl_interfaces::msg::IntegerRange intervalRange;
-	intervalRange.from_value = 1000;
-	intervalRange.to_value   = 1000000;
-	intervalRange.step 		 = 1;
-
-	// Read timer interval
-	rcl_interfaces::msg::ParameterDescriptor read_description = rcl_interfaces::msg::ParameterDescriptor();
-	ss << 	"Parameter for controlling sensor serial polling period in microseconds (μs)\n" <<
-			"  Default: " << DEFAULT_TIMER_PERIOD << "μs";
-	read_description.name = "read_us";
-	read_description.description = ss.str();
-	ss.str(""); // empty the stream
-	read_description.integer_range.push_back(intervalRange);
-	this->declare_parameter<int>("read_us", DEFAULT_TIMER_PERIOD, read_description);
-	if( validateReadUs( this->get_parameter("read_us") ).successful ) { // Check that it is valid and save
-		read_timer_interval_ = std::chrono::microseconds(this->get_parameter("read_us").as_int());
-	}else { // If invalid save default.
-		RCLCPP_ERROR(this->get_logger(), "Invalid period. Setting to default: %d", DEFAULT_TIMER_PERIOD);
-		this->set_parameter(rclcpp::Parameter("read_us", DEFAULT_TIMER_PERIOD));
-		read_timer_interval_ = std::chrono::microseconds(DEFAULT_TIMER_PERIOD);
-	}
-
-	// Publish timer interval
-	rcl_interfaces::msg::ParameterDescriptor publish_description = rcl_interfaces::msg::ParameterDescriptor();
-	ss << 	"Parameter for controlling ROS publishing period in microseconds (μs)\n" <<
-			"  Default: " << DEFAULT_TIMER_PERIOD << "μs";
-	publish_description.description = ss.str();
-	ss.str(""); // empty the stream
-	publish_description.name = "publish_us";
-	publish_description.integer_range.push_back(intervalRange);
-	publish_description.additional_constraints = "Value must be greater than read_us";
-	this->declare_parameter<int>("publish_us", DEFAULT_TIMER_PERIOD, publish_description);
-	if( validatePublishUs( this->get_parameter("publish_us") ).successful ) { // Check that it is valid and save
-		publish_timer_interval_ = std::chrono::microseconds(this->get_parameter("publish_us").as_int());
-	}else { // If invalid save default.
-		// Is the current read_us higher than the default set it to read_us
-		if(DEFAULT_TIMER_PERIOD < this->get_parameter("read_us").as_int()) {
-			RCLCPP_ERROR(this->get_logger(), "Invalid period. Setting to read_us: %ld", this->get_parameter("read_us").as_int());
-			this->set_parameter(rclcpp::Parameter("publish_us", this->get_parameter("read_us").as_int()));
-			publish_timer_interval_ = std::chrono::microseconds(this->get_parameter("read_us").as_int());
-		}else { // otherwise set to default.
-			RCLCPP_ERROR(this->get_logger(), "Invalid period. Setting to default: %d", DEFAULT_TIMER_PERIOD);
-			this->set_parameter(rclcpp::Parameter("publish_us", DEFAULT_TIMER_PERIOD));
-			publish_timer_interval_ = std::chrono::microseconds(DEFAULT_TIMER_PERIOD);
-		}
-	}
-
-
-
-	// Request packet array
-	rcl_interfaces::msg::ParameterDescriptor packet_request_description = rcl_interfaces::msg::ParameterDescriptor();
-	ss << 	"\tInteger Vector for Requested Packet ID's and their Period\n" <<
-			"\t\tSee ANPP Documentation for more information on packets and IDs and Periods\n" <<
-			"  Usage: [ID1, Period1, ID2, Period2, ...]\n" <<
-			"  Default: [20, 10, 28, 10]";
-	packet_request_description.description = ss.str();
-	ss.str(""); // empty the stream
-	packet_request_description.name = "packet_request";
-	ss << 	"Must contain a minimum of 1 packet, every packet ID must have a corresponding rate.\n"<<
-			"\tFor IDs:\n" <<
-			"\t  Status Packets: [0-" << end_system_packets-1 << "]\n" <<
-			"\t  State Packets: [" << START_STATE_PACKETS << "-" << end_state_packets-1 << "]\n" <<
-			"\t  Configuration Packets: [" << START_CONFIGURATION_PACKETS << "-" << end_configuration_packets-1 << "]\n" <<
-			"\tFor Periods:\n" <<
-			"\t  Min value: " << MIN_PACKET_PERIOD << "\n" <<
-			"\t  Max value: " << MAX_PACKET_PERIOD << "\n" <<
-			"\t  Step: " << 1;
-	packet_request_description.additional_constraints = ss.str();
-	ss.str(""); // empty the stream
-	std::vector<int64_t> default_vector(DEFAULT_PACKET_REQUEST, DEFAULT_PACKET_REQUEST + (sizeof(DEFAULT_PACKET_REQUEST)/sizeof(DEFAULT_PACKET_REQUEST[0])));
-	this->declare_parameter("packet_request", rclcpp::ParameterValue(default_vector), packet_request_description);
-	if( validatePacketRequest( this->get_parameter("packet_request") ).successful ) { // Check that it is valid and save
-		packet_request_ = this->get_parameter("packet_request").as_integer_array();
-	}else { // If invalid save default.
-		RCLCPP_ERROR(this->get_logger(), "Invalid packet request. Setting to default: %s", DEFAULT_PACKET_REQUEST_STR);
-		this->set_parameter(rclcpp::Parameter("packet_request", default_vector));
-		packet_request_ = default_vector;
-	}
-
-	// Packet Timer Period
-	rcl_interfaces::msg::ParameterDescriptor packet_timer_period_description = rcl_interfaces::msg::ParameterDescriptor();
-	ss << 	"\tInteger value for Packet Timing Period in μs\n"<<
-			"\t\tSee ANPP Documentation for more information on Packets and IDs\n" <<
-			"  Default: 10,000";
-	packet_timer_period_description.description = ss.str();
-	ss.str(""); // empty the stream
-	packet_timer_period_description.name = "packet_timer_period";
-	rcl_interfaces::msg::IntegerRange ptpdRange;
-	ptpdRange.from_value = MIN_TIMER_PERIOD;
-	ptpdRange.to_value   = MAX_TIMER_PERIOD;
-	ptpdRange.step 		 = 1;
-	packet_timer_period_description.integer_range.push_back(ptpdRange);
-	this->declare_parameter<int>("packet_timer_period", 10000, packet_timer_period_description);
-	if( validatePacketTimer(this->get_parameter("packet_timer_period") ).successful) { // Check that it is valid and save
-		packet_timer_period_ = (int) this->get_parameter("packet_timer_period").as_int();
-	}else {// If invalid save default.
-		RCLCPP_ERROR(this->get_logger(), "Invalid packet timer period. Setting to default: %d", DEFAULT_PACKET_TIMER_PERIOD);
-		this->set_parameter(rclcpp::Parameter("packet_timer_period", DEFAULT_PACKET_TIMER_PERIOD));
-		packet_timer_period_ = DEFAULT_PACKET_TIMER_PERIOD;
-	}
-
-	// IP Address - Read only
-	rcl_interfaces::msg::ParameterDescriptor ip_address_description = rcl_interfaces::msg::ParameterDescriptor();
-	ss << 	"IPv4 address to connect to the device on.\n"<<
-			"  Default: 0.0.0.0";
-	ip_address_description.description = ss.str();
-	ss.str(""); // empty the stream
-	ip_address_description.name = "ip_address";
-	ip_address_description.read_only = true;
-	this->declare_parameter<std::string>("ip_address", DEFAULT_IP_ADDRESS, ip_address_description);
-	comms_data_.ip_address = this->get_parameter("ip_address").as_string();
-
-	// Port - Read only
-	rcl_interfaces::msg::ParameterDescriptor ip_port_description = rcl_interfaces::msg::ParameterDescriptor();
-	ss << 	"Port to connect to the Advanced Navigation device on\n"<<
-			"  Default: 0";
-	ip_port_description.description = ss.str();
-	ss.str(""); // empty the stream
-	ip_port_description.name = "port";
-	ip_port_description.read_only = true;
-	rcl_interfaces::msg::IntegerRange portRange;
-	portRange.from_value = MIN_PORT;
-	portRange.to_value   = MAX_PORT;
-	portRange.step 		 = 1;
-	ip_port_description.integer_range.push_back(portRange);
-	this->declare_parameter<int>("port", 0, ip_port_description);
-	comms_data_.port = (int) this->get_parameter("port").as_int();
-
-	// Logging Path - Read Only
-	rcl_interfaces::msg::ParameterDescriptor log_path_description = rcl_interfaces::msg::ParameterDescriptor();
-	ss << "Path for all logfiles to be placed. Default '~/.ros/log/'\n";
-	log_path_description.description = ss.str();
-	ss.str("");
-	log_path_description.name = "log_path";
-	log_path_description.read_only = true;
-	this->declare_parameter<std::string>("log_path", "~/.ros/log/", log_path_description);
-	log_path_ = this->get_parameter("log_path").as_string();
-
-
-	// Comms Select - Read only
-	rcl_interfaces::msg::ParameterDescriptor comms_select_description = rcl_interfaces::msg::ParameterDescriptor();
-	ss << 	"What method will be used to communicate with the device.\n"<<
-			"  Default: 0: Serial\n" <<
-			"  1: TCP Client\n" <<
-			"  2: TCP Server\n" <<
-			"  3: UDP\n" <<
-			"  4: CAN\n";
-	comms_select_description.description = ss.str();
-	ss.str(""); // empty the stream
-	comms_select_description.name = "comm_select";
-	comms_select_description.read_only = true;
-	rcl_interfaces::msg::IntegerRange commRange;
-	commRange.from_value = 0;
-	commRange.to_value   = 4;
-	commRange.step 		 = 1;
-	comms_select_description.integer_range.push_back(commRange);
-	this->declare_parameter<int>("comm_select", adnav::CONNECTION_SERIAL, comms_select_description);
-	comms_data_.method = this->get_parameter("comm_select").as_int();
-
-	rcl_interfaces::msg::ParameterDescriptor convert_desc;
-	convert_desc.description = "Convert ENU Twist to FLU Twist.\n"
-		"  Default: false\n"
-		"  If true, the ENU Twist will be converted to FLU Twist before publishing.";
-	convert_desc.read_only = true;
-	convert_twist_enu_to_flu_ = this->declare_parameter<bool>("convert_twist_enu_to_flu", false, convert_desc);
 }
 
 //~~~~~~ Control Functions
@@ -589,9 +375,10 @@ void Driver::RestartPublisher() {
 	// Cancel old timer to stop callbacks from triggering while remaking timer.
 	publish_timer_->cancel();
 
+	const auto params = param_listener_->get_params();
 	// Reset the timer using the class stored interval.
 	publish_timer_ = this->create_wall_timer(
-      	publish_timer_interval_ , std::bind(&Driver::publishTimerCallback, this), publishing_group_);
+      	std::chrono::microseconds(params.publish_us), std::bind(&Driver::publishTimerCallback, this), publishing_group_);
 }
 
 /**
@@ -603,9 +390,11 @@ void Driver::RestartReader() {
 	// Cancel old timer to stop callbacks from triggering while remaking timer.
 	read_timer_->cancel();
 
+	const auto params = param_listener_->get_params();
+
 	// Reset the timer using the class stored interval.
 	read_timer_ = this->create_wall_timer(
-		read_timer_interval_, std::bind(&Driver::recievePackets, this), reading_group_);
+		std::chrono::microseconds(params.read_us), std::bind(&Driver::recievePackets, this), reading_group_);
 }
 
 //~~~~~~ Diagnostic Functions
@@ -1055,9 +844,7 @@ rcl_interfaces::msg::SetParametersResult Driver::validatePublishUs(const rclcpp:
  *
  * @param parameter const rclcpp::Parameter. updated Publish us parameter
  */
-void Driver::updatePublishUs(const rclcpp::Parameter& parameter) {
-	publish_timer_interval_ = std::chrono::microseconds(parameter.as_int());
-
+void Driver::updatePublishUs([[maybe_unused]] const rclcpp::Parameter& parameter) {
 	RestartPublisher();
 }
 
@@ -1109,9 +896,7 @@ rcl_interfaces::msg::SetParametersResult Driver::validateReadUs(const rclcpp::Pa
  *
  * @param parameter const rclcpp::Parameter. updated Read us parameter
  */
-void Driver::updateReadUs(const rclcpp::Parameter& parameter) {
-	read_timer_interval_ = std::chrono::microseconds(parameter.as_int());
-
+void Driver::updateReadUs([[maybe_unused]] const rclcpp::Parameter& parameter) {
 	RestartReader();
 }
 
@@ -1150,7 +935,7 @@ rcl_interfaces::msg::SetParametersResult Driver::validatePacketRequest(const rcl
 	}
 
 	// Check all elements of the request array
-	for(unsigned int i = 0; i < parameter.as_integer_array().size(); i++) {
+	for(std::size_t i = 0; i < parameter.as_integer_array().size(); i++) {
 		// if even (ID)
 		int64_t element = parameter.as_integer_array().at(i);
 		if(i%2 == 0) {
@@ -1176,25 +961,27 @@ rcl_interfaces::msg::SetParametersResult Driver::validatePacketRequest(const rcl
 	return result;
 }
 
+std::vector<adnav_interfaces::msg::PacketPeriod> Driver::getPacketRequest() {
+	std::vector<adnav_interfaces::msg::PacketPeriod> packet_periods;
+	const auto params = param_listener_->get_params();
+
+	// Create and fill a periods format.
+	for(std::size_t i = 0; (i+i) < params.packet_request.size(); i++) {
+		adnav_interfaces::msg::PacketPeriod period;
+		period.packet_id = params.packet_request[i+i];
+		period.packet_period = params.packet_request[i+i+1];
+		packet_periods.push_back(period);
+	}
+	return packet_periods;
+}
+
 /**
- * @brief Function to Update the Packet Request parameter, create temporary service client and update the device using service
+ * @brief Function to Update the Packet Request parameter
  *
  * @param parameter const rclcpp::Parameter. updated Packet Request parameter
  */
-void Driver::updatePacketRequest(const rclcpp::Parameter& parameter) {
-
-	packet_request_ = parameter.as_integer_array();
-
-	// Create and fill a periods format.
-	std::vector<adnav_interfaces::msg::PacketPeriod> packet_periods;
-	for(uint64_t i = 0; (i+i) < packet_request_.size(); i++) {
-		adnav_interfaces::msg::PacketPeriod period;
-		period.packet_id = packet_request_[i+i];
-		period.packet_period = packet_request_[i+i+1];
-		packet_periods.push_back(period);
-	}
-
-	(void) SendPacketPeriods(packet_periods);
+void Driver::updatePacketRequest([[maybe_unused]] const rclcpp::Parameter& parameter) {
+	SendPacketPeriods(getPacketRequest());
 }
 
 /**
@@ -1235,11 +1022,10 @@ rcl_interfaces::msg::SetParametersResult Driver::validatePacketTimer(const rclcp
  *
  * @param parameter const rclcpp::Parameter. updated PacketTimer parameter
  */
-void Driver::updatePacketTimer(const rclcpp::Parameter& parameter) {
-	packet_timer_period_ = (int) parameter.as_int();
-
+void Driver::updatePacketTimer([[maybe_unused]] const rclcpp::Parameter& parameter) {
 	// Send to the device.
-	(void) SendPacketTimer(packet_timer_period_);
+	const auto params = param_listener_->get_params();
+	SendPacketTimer(params.packet_timer_period);
 }
 
 //~~~~~~ NTRIP Functions
@@ -1277,9 +1063,10 @@ void Driver::updateNTRIPClientService() {
 	ntrip_client_->set_report_interval(DEFAULT_GPGGA_REPORT_PERIOD);
 	ntrip_client_->set_location(llh_.latitude, llh_.longitude, llh_.height);
 
+	const auto params = param_listener_->get_params();
 	// Guard to stop bad hostend return.
 	if(ntrip_state_.he != nullptr) {
-		rtcm_logger_.openFile((std::string("Log_") + std::string(ntrip_state_.he->h_name)), ".rtcm", log_path_);
+		rtcm_logger_.openFile((std::string("Log_") + std::string(ntrip_state_.he->h_name)), ".rtcm", params.log_path);
 	}
 }
 
@@ -1483,7 +1270,7 @@ adnav_interfaces::msg::RawAcknowledge Driver::SendPacketPeriods(const std::vecto
 
 	int j = 0;
 	for(adnav_interfaces::msg::PacketPeriod i : periods) {
-		ss << "\tID: " << (int)i.packet_id << "\tPeriod: "<< i.packet_period << std::endl;
+		ss << "\tID: " << static_cast<int>(i.packet_id) << "\tPeriod: "<< i.packet_period << std::endl;
 		packet_periods_packet.packet_periods[j].packet_id = i.packet_id;
 		packet_periods_packet.packet_periods[j].period = i.packet_period;
 		j++;
@@ -1516,7 +1303,7 @@ void Driver::decodePackets(an_decoder_t &an_decoder, const int &bytes) {
 		an_decoder_increment(&an_decoder, bytes);
 
 		// Decode all the packets in the buffer
-		while ((an_packet = an_packet_decode(&an_decoder)) != NULL)
+		while ((an_packet = an_packet_decode(&an_decoder)) != nullptr)
 		 {
 			RCLCPP_DEBUG(this->get_logger(), "ID: %d", an_packet->id);
 
@@ -1653,7 +1440,7 @@ void Driver::deviceInfoDecoder(an_packet_t* an_packet) {
  * @param an_packet a pointer to an an_packet_t object which will be decoded.
  */
 void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
-
+	const auto params = param_listener_->get_params();
 	system_state_packet_t system_state_packet;
 	std::stringstream ss;
 	std::unique_lock<std::mutex> lock(messages_mutex_);
@@ -1714,16 +1501,20 @@ void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
 			);
 
 			// TWIST
-			twist_msg_.linear.x = system_state_packet.velocity[0];
-			twist_msg_.linear.y = system_state_packet.velocity[1];
-			twist_msg_.linear.z = system_state_packet.velocity[2];
+
+			if (!params.use_body_velocity)
+			{
+				twist_msg_.linear.x = system_state_packet.velocity[0];
+				twist_msg_.linear.y = system_state_packet.velocity[1];
+				twist_msg_.linear.z = system_state_packet.velocity[2];
+
+				if (params.convert_twist_enu_to_flu) {
+					twist_msg_ = transformTwistEnuToFlu(twist_msg_, orientation_);
+				}
+			}
 			twist_msg_.angular.x = system_state_packet.angular_velocity[0];
 			twist_msg_.angular.y = system_state_packet.angular_velocity[1];
 			twist_msg_.angular.z = system_state_packet.angular_velocity[2];
-
-			if (convert_twist_enu_to_flu_) {
-				twist_msg_ = transformTwistEnuToFlu(twist_msg_, orientation_);
-			}
 
 			twist_stamped_msg_.twist = twist_msg_;
 			twist_stamped_msg_.header = nav_fix_msg_.header;

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -682,6 +682,15 @@ void Driver::accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &st
 			stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No GNSS 3D Fix");
 		}
 
+		if (params.health.external_velocity)
+		{
+			stat.add("External Velocity Active", system_state_packet_->filter_status.b.external_velocity_active ? "Yes" : "No");
+			if (!system_state_packet_->filter_status.b.external_velocity_active)
+			{
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No External Velocity");
+			}
+		}
+
 		auto [rms_2d, rms_3d] = position_accuracy_rms(*system_state_packet_);
 		stat.add("Position Accuracy (2D RMS) (m)", std::to_string(rms_2d));
 		stat.add("Position Accuracy (3D RMS) (m)", std::to_string(rms_3d));

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -607,22 +607,6 @@ void Driver::system_status_diagnostic(diagnostic_updater::DiagnosticStatusWrappe
 			stat.add("GNSS", "Fail");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
 		}
-		if (sys_state_pkt->system_status.b.accelerometer_over_range) {
-			stat.add("Accelerometer Over Range", "Fail");
-			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-		}
-		if (sys_state_pkt->system_status.b.gyroscope_over_range) {
-			stat.add("Gyroscope Over Range", "Fail");
-			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-		}
-		if (sys_state_pkt->system_status.b.magnetometer_over_range) {
-			stat.add("Magnetometer", " Over Range");
-			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-		}
-		if (sys_state_pkt->system_status.b.pressure_over_range) {
-			stat.add("Pressure Sensor", " Over Range");
-			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-		}
 		if (sys_state_pkt->system_status.b.minimum_temperature_alarm) {
 			stat.add("Temperature Alarm", "Minimum Temperature Alarm");
 			stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
@@ -760,6 +744,27 @@ void Driver::accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &st
 		const auto params = param_listener_->get_params();
 
 		stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+
+		stat.add("Accelerometer In Range", sys_state_pkt->system_status.b.accelerometer_over_range ? "Fail" : "OK");
+		stat.add("Gyroscope In Range", sys_state_pkt->system_status.b.gyroscope_over_range ? "Fail" : "OK");
+		stat.add("Magnetometer In Range", sys_state_pkt->system_status.b.magnetometer_over_range ? "Fail" : "OK");
+		stat.add("Pressure Sensor In Range", sys_state_pkt->system_status.b.pressure_over_range ? "Fail" : "OK");
+
+		if (params.health.sensors_in_range)
+		{
+			if (sys_state_pkt->system_status.b.accelerometer_over_range) {
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Accelerometer Over Range");
+			}
+			if (sys_state_pkt->system_status.b.gyroscope_over_range) {
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Gyroscope Over Range");
+			}
+			if (sys_state_pkt->system_status.b.magnetometer_over_range) {
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Magnetometer Over Range");
+			}
+			if (sys_state_pkt->system_status.b.pressure_over_range) {
+				stat.mergeSummary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Pressure Sensor Over Range");
+			}
+		}
 
 		if (params.health.filters_initialised)
 		{

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -207,30 +207,10 @@ void Driver::createPublishers() {
  * @brief Function to declare and assign callbacks to services for the adnav_driver node.
  */
 void Driver::createServices() {
-	packet_period_srv_ = this->create_service<adnav_interfaces::srv::PacketPeriods>(
-		"~/packet_periods",
-		std::bind(
-			&Driver::srvPacketPeriods,
-			this,
-			std::placeholders::_1,
-			std::placeholders::_2),
-		rclcpp::ServicesQoS(),
-		service_group_);
-
 	packet_period_timer_srv_ = this->create_service<adnav_interfaces::srv::PacketTimerPeriod>(
 		"~/packet_timer_period",
 		std::bind(
 			&Driver::srvPacketTimerPeriod,
-			this,
-			std::placeholders::_1,
-			std::placeholders::_2),
-		rclcpp::ServicesQoS(),
-		service_group_);
-
-	request_packet_srv_ = this->create_service<adnav_interfaces::srv::RequestPackets>(
-		"~/request_packet",
-		std::bind(
-			&Driver::srvRequestPackets,
 			this,
 			std::placeholders::_1,
 			std::placeholders::_2),
@@ -755,30 +735,6 @@ void Driver::filter_status_diagnostic(diagnostic_updater::DiagnosticStatusWrappe
 //~~~~~~ Service Functions
 
 /**
- * @brief Service to update the Packet Periods from the device.
- *
- * Communicates to the device and receives an acknowledgement packet.
- *
- * @param request Const shared pointer to a PacketPeriods request.
- * @param response Shared pointer to a PacketPeriods response.
- */
-void Driver::srvPacketPeriods(const std::shared_ptr<adnav_interfaces::srv::PacketPeriods::Request> request,
-		std::shared_ptr<adnav_interfaces::srv::PacketPeriods::Response> response) {
-
-	// Send Config to device
-	SendPacketPeriods(request->periods, request->clear_existing_periods);
-
-	// Await the response
-	response->acknowledgement = AcknowledgeHandler();
-
-	// notify of result.
-	char buf[15];
-	snprintf(buf, sizeof(buf)/sizeof(buf[0]), "%s%d%s", "Failure: ", response->acknowledgement.result, "\n");
-	RCLCPP_INFO(this->get_logger(), "Received Update acknowledgement:\nID: %d\tCRC: %d\nOutcome: %s", response->acknowledgement.id,
-            response->acknowledgement.crc, (response->acknowledgement.result == 0) ? "Success\n":buf);
-}
-
-/**
  * @brief Service to request a change of Packet Timer Period from the device.
  *
  * @param request Const shared pointer to a PacketTimerPeriod Request msg
@@ -798,28 +754,6 @@ void Driver::srvPacketTimerPeriod(const std::shared_ptr<adnav_interfaces::srv::P
 	snprintf(buf, sizeof(buf)/sizeof(buf[0]), "%s%d%s", "Failure: ", response->acknowledgement.result, "\n");
 	RCLCPP_INFO(this->get_logger(), "Received Update acknowledgement:\nID: %d\tCRC: %d\nOutcome: %s", response->acknowledgement.id,
             response->acknowledgement.crc, (response->acknowledgement.result == 0) ? "Success\n":buf);
-}
-
-/**
- * @brief Service to request a series of packets from the device.
- *
- * @param request Const shared pointer to a RequestPackets Request msg
- * @param response Shared pointer to a RequestPackets Response.
- */
-void Driver::srvRequestPackets(const std::shared_ptr<adnav_interfaces::srv::RequestPackets::Request> request,
-		std::shared_ptr<adnav_interfaces::srv::RequestPackets::Response> response) {
-
-	an_packet_t *an_packet;
-
-	RCLCPP_INFO(this->get_logger(), "Incoming Packet Request:");
-
-	for(auto& i : request->packet_ids) {
-		RCLCPP_INFO(this->get_logger(), "Requesting ID: %d", i);
-		an_packet = encode_request_packet(i);
-		encodeAndSend(an_packet);
-	}
-
-	response->success = true;
 }
 
 void Driver::srvNtrip(const std::shared_ptr<adnav_interfaces::srv::Ntrip::Request> request,
@@ -1490,7 +1424,7 @@ adnav_interfaces::msg::RawAcknowledge Driver::AcknowledgeHandler() {
  * @brief Function to send the packet Timer to the device and await the acknowledgement.
  *
  * @param packet_timer_period Period for the packet rates in microseconds.
- * @param UTC_sync Synchronize with UTC time. True by default.
+ * @param utc_sync Synchronize with UTC time. True by default.
  * @param permanent Is this a permanent change. True by default.
  * @return acknowledgement Message
  */

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -1828,18 +1828,17 @@ void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
 			);
 
 			// TWIST
-
 			twist_msg_.linear.x = system_state_packet.velocity[0];
 			twist_msg_.linear.y = system_state_packet.velocity[1];
 			twist_msg_.linear.z = system_state_packet.velocity[2];
 
-			if (params.convert_twist_enu_to_flu) {
-				twist_msg_ = transformTwistEnuToFlu(twist_msg_, orientation_);
-			}
-
 			twist_msg_.angular.x = system_state_packet.angular_velocity[0];
 			twist_msg_.angular.y = system_state_packet.angular_velocity[1];
 			twist_msg_.angular.z = system_state_packet.angular_velocity[2];
+
+			if (params.convert_twist_enu_to_flu) {
+				twist_msg_ = transformTwistEnuToFlu(twist_msg_, orientation_);
+			}
 
 			twist_stamped_msg_.twist = twist_msg_;
 			twist_stamped_msg_.header = nav_fix_msg_.header;

--- a/adnav_driver/src/adnav_driver.cpp
+++ b/adnav_driver/src/adnav_driver.cpp
@@ -1823,7 +1823,7 @@ void Driver::systemStateRosDecoder(an_packet_t* an_packet) {
 			// Using the RPY orientation as done by cosama
 			orientation_.setRPY(
 				system_state_packet.orientation[0],
-				system_state_packet.orientation[1],
+				-system_state_packet.orientation[1],
 				M_PI/2.0f - system_state_packet.orientation[2] // REP 103
 			);
 

--- a/adnav_driver/src/adnav_driver.hpp
+++ b/adnav_driver/src/adnav_driver.hpp
@@ -162,6 +162,7 @@ class Driver : public rclcpp::Node
     sensor_msgs::msg::Temperature   temp_msg_;
     geometry_msgs::msg::Twist       twist_msg_;
     geometry_msgs::msg::TwistStamped twist_stamped_msg_;
+    geometry_msgs::msg::TwistStamped twist_stamped_msg_body;
     geometry_msgs::msg::TwistStamped twist_stamped_msg_external_body;
     geometry_msgs::msg::PoseStamped pose_stamped_msg_;
     geometry_msgs::msg::Pose        pose_msg_;
@@ -180,6 +181,7 @@ class Driver : public rclcpp::Node
     rclcpp::Publisher<sensor_msgs::msg::Temperature>::SharedPtr 			temperature_pub_;
     rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr 				twist_pub_;
     rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr 			twist_stamped_pub_;
+    rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr 			twist_stamped_body_velocity_pub_;
     rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr 			twist_stamped_external_body_pub_;
     rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr 					pose_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr 			pose_stamped_pub_;

--- a/adnav_driver/src/adnav_driver.hpp
+++ b/adnav_driver/src/adnav_driver.hpp
@@ -31,7 +31,6 @@
 
 // C System Headers
 #include <stdio.h>      // FILE
-#include <sstream>      // Stringstream
 #include <fstream>
 
 // C++ System Headers
@@ -65,7 +64,6 @@
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include <tf2/LinearMath/Quaternion.h>
 #include <rcl_interfaces/msg/set_parameters_result.hpp>
-#include <std_msgs/msg/string.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/time_reference.hpp>
 #include <sensor_msgs/msg/imu.hpp>

--- a/adnav_driver/src/adnav_driver.hpp
+++ b/adnav_driver/src/adnav_driver.hpp
@@ -26,29 +26,33 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#pragma once
+
 #ifndef ADVANCED_NAVIGATION_DRIVER_H
 #define ADVANCED_NAVIGATION_DRIVER_H
 
-// C System Headers
-#include <stdio.h>      // FILE
+#include <cstdio>
 #include <fstream>
 
 // C++ System Headers
-#include <chrono>       // Time, std::chrono
-#include <functional>   // std::placeholder
-#include <memory>       // smart pointers
-#include <vector>       // std::vector
-#include <string>       // std::string
-#include <mutex>        // std::mutex, std:unique_lock
-#include <condition_variable>   // std::condition_variable
+#include <chrono>           // Time, std::chrono
+#include <memory>           // smart pointers
+#include <vector>           // std::vector
+#include <string>           // std::string
+#include <mutex>            // std::mutex, std::unique_lock
+#include <future>           // std::promise, std::future
+#include <queue>            // std::queue
+#include <unordered_map>    // std::unordered_map
+#include <thread>
 
-#include <rs232.h>
 #include <an_packet_protocol.h>
 #include <ins_packets.h>
-#include <adnav_utils.h>
-#include <adnav_comms.h>
 #include <adnav_logger.h>
 #include <adnav_ntrip.h>
+
+#include "anpp.hpp"
+
+#include "uvw.hpp"
 
 #include <adnav_driver/adnav_parameters.hpp>
 
@@ -78,45 +82,32 @@
 #include <geographic_msgs/msg/geo_pose.hpp>
 #include <geographic_msgs/msg/geo_pose_stamped.hpp>
 
-#if defined(WIN32) || defined(_WIN32)
-    #pragma comment(lib, "ws2_32.lib")  // Winsock Library
-    #pragma comment(lib, "iphlpapi.lib")  // IP Help API Library
-    #include<winsock2.h>
-    #include<iphlpapi.h>
-    #include<netioapi.h>
-    #include<WS2tcpip.h>
-#else
-    #include <unistd.h>
-    #include <netdb.h>
-    #include <ifaddrs.h>
-    #include <sys/socket.h>
-    #include <arpa/inet.h>
-#endif
-
-#define _USE_MATH_DEFINES
-#include <math.h>
 #include <cmath>
 
 
 namespace adnav {
 
-constexpr const double RADIANS_TO_DEGREES = (180.0/M_PI);
-constexpr const int    DEFAULT_BAUD_RATE = 115200;
-constexpr const int    DEFAULT_TIMER_PERIOD = 20000;
-constexpr const int    DEFAULT_PACKET_TIMER_PERIOD = 10000;
-constexpr const char * DEFAULT_COM_PORT = "ttyUSB0";
-constexpr const int    DEFAULT_PACKET_REQUEST[4] = {20, 10, 28, 10};
-constexpr const char * DEFAULT_PACKET_REQUEST_STR = "20, 10, 28, 10";
-constexpr const char * DEFAULT_IP_ADDRESS = "0.0.0.0";
-constexpr const bool   DEFAULT_NTRIP_STATE = false;
-constexpr const int    DEFAULT_GPGGA_REPORT_PERIOD = 1;  // Second(s)
-constexpr const int    DEFAULT_TIMEOUT = 5;
-constexpr const int    MAX_TIMER_PERIOD = 65535;
-constexpr const int    MIN_TIMER_PERIOD = 1000;
-constexpr const int    MIN_PACKET_PERIOD = 1;
-constexpr const int    MAX_PACKET_PERIOD = 65535;
-constexpr const int    MIN_PORT = 0;
-constexpr const int    MAX_PORT = 65535;
+    struct PacketIdTime {
+        uint8_t packet_id;
+        std::chrono::microseconds period;
+    };
+
+    inline constexpr std::array<PacketIdTime, 5> REQUIRED_PACKETS = {
+        {
+            {packet_id_system_state, std::chrono::microseconds(50)},
+            {packet_id_raw_sensors, std::chrono::microseconds(50)},
+            {packet_id_body_velocity, std::chrono::microseconds(50)},
+            {packet_id_euler_orientation_standard_deviation, std::chrono::microseconds(50)},
+            {packet_id_velocity_standard_deviation, std::chrono::microseconds(50)}
+        }};
+
+constexpr double RADIANS_TO_DEGREES = (180.0/M_PI);
+constexpr int    DEFAULT_GPGGA_REPORT_PERIOD = 1;  // Second(s)
+constexpr int    DEFAULT_TIMEOUT = 2;
+constexpr int    MAX_TIMER_PERIOD = 65535;
+constexpr int    MIN_TIMER_PERIOD = 1000;
+constexpr int    MIN_PACKET_PERIOD = 1;
+constexpr int    MAX_PACKET_PERIOD = 65535;
 
 typedef struct {
     bool en;
@@ -126,19 +117,15 @@ typedef struct {
     std::string username;
     std::string password;
     std::string mountpoint;
-}ntrip_client_state_t;
+} ntrip_client_state_t;
 
-class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a pointer to the node.
+class Driver : public rclcpp::Node
 {
  public:
-    // ~~~~ Constructors
     Driver();
-    ~Driver();
+    ~Driver() override;
 
  private:
-    // Debug variables
-    int pub_num_ = 0, P28_num_ = 0, P20_num_ = 0, P27_num_ = 0, P33_num_ = 0, P0_num_ = 0;
-
     std::shared_ptr<adnav::ParamListener> param_listener_;
 
     // String to hold frame_id
@@ -146,16 +133,24 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     std::string external_frame_id_ = "map";
 
     // device communication settings
-    std::unique_ptr<adnav::Communicator> communicator_;
+    std::jthread connection_thread_;
+    std::jthread setup_thread_;                     // runs deviceSetup() off the event loop
+    std::shared_ptr<uvw::async_handle> close_async_;
+    std::shared_ptr<uvw::async_handle> write_async_;
+
+    // Write queue — encodeAndSend pushes here; write_async_ drains it on the loop thread
+    std::mutex write_q_mutex_;
+    std::queue<std::pair<std::unique_ptr<char[]>, unsigned int>> write_q_;
 
     // Log files.
     adnav::Logger anpp_logger_;
     adnav::Logger rtcm_logger_;
 
     // ANPP Packet variables
-    acknowledge_packet_t acknowledge_packet_;  // only access with protection of acknowledge_mutex_
     std::optional<device_information_packet_t> device_information_packet_;
     std::optional<system_state_packet_t> system_state_packet_;
+    std::optional<euler_orientation_standard_deviation_packet_t> euler_orientation_standard_deviation_packet_;
+    std::optional<velocity_standard_deviation_packet_t> velocity_standard_deviation_packet_;
 
     // Msgs. Only access with protection of messages_mutex_
     tf2::Quaternion                 orientation_;
@@ -202,13 +197,11 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     OnSetParametersCallbackHandle::SharedPtr param_set_cb_;
     std::shared_ptr<rclcpp::ParameterEventHandler> param_handler_;
     std::shared_ptr<rclcpp::ParameterCallbackHandle> publish_us_cb_;
-    std::shared_ptr<rclcpp::ParameterCallbackHandle> read_us_cb_;
     std::shared_ptr<rclcpp::ParameterCallbackHandle> packet_request_cb_;
     std::shared_ptr<rclcpp::ParameterCallbackHandle> packet_timer_cb_;
 
     // Timers
     rclcpp::TimerBase::SharedPtr publish_timer_;
-    rclcpp::TimerBase::SharedPtr read_timer_;
 
     // Service Handlers
     rclcpp::Service<adnav_interfaces::srv::PacketTimerPeriod>::SharedPtr packet_period_timer_srv_;
@@ -218,12 +211,16 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
 
     // Threading variables
     std::mutex messages_mutex_;
-    std::condition_variable msg_cv_;
-    bool msg_write_done_;
 
-    std::mutex acknowledge_mutex_;
-    std::condition_variable srv_cv_;
-    bool acknowledge_recieve_;
+    // Pending request-reply tracking. Keyed by the expected reply packet_id.
+    // Works for any packet type — register a PendingReply before sending, and
+    // decodePackets will dispatch it when that packet_id arrives.
+    struct PendingReply {
+        std::function<void(an_packet_t*)>       on_packet;  // called on the loop thread with the reply
+        std::function<void(std::exception_ptr)> on_cancel;  // called when the connection drops
+    };
+    std::mutex pending_replies_mutex_;
+    std::unordered_map<uint8_t, PendingReply> pending_replies_;
 
     // NTRIP Variables
     std::unique_ptr<adnav::ntrip::Client> ntrip_client_;
@@ -235,22 +232,22 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     //~~~~~~~~~~~~~~~~~~~~~ Private Methods.
 
     //~~~~~~ Setup Functions
-    void waitForDevicePacket();
-    void requestDeviceInfo();
+    bool requestDeviceInfo();
+    void deviceSetup();
+
     void createPublishers();
     void createServices();
-    void deviceSetup();
     void setupParamService();
 
     //~~~~~~ Control Functions
-    void recievePackets();
+    void receivePackets(std::span<const uint8_t> buffer);
     void publishTimerCallback();
     void RestartPublisher();
-    void RestartReader();
 
     //~~~~~~ Logging Functions
     void system_status_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
     void filter_status_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+    void accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
 
     //~~~~~~ ROS Services
     void srvPacketTimerPeriod(const std::shared_ptr<adnav_interfaces::srv::PacketTimerPeriod::Request> request,
@@ -261,12 +258,9 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
     //~~~~~~ Parameter Functions
     std::vector<adnav_interfaces::msg::PacketPeriod> getPacketRequest();
     rcl_interfaces::msg::SetParametersResult ParamSetCallback(const std::vector<rclcpp::Parameter>& Params);
-    rcl_interfaces::msg::SetParametersResult validateBaudRate(const rclcpp::Parameter& parameter);
     rcl_interfaces::msg::SetParametersResult validateComPort(const rclcpp::Parameter& parameter);
     rcl_interfaces::msg::SetParametersResult validatePublishUs(const rclcpp::Parameter& parameter);
     void updatePublishUs(const rclcpp::Parameter& parameter);
-    rcl_interfaces::msg::SetParametersResult validateReadUs(const rclcpp::Parameter& parameter);
-    void updateReadUs(const rclcpp::Parameter& parameter);
     rcl_interfaces::msg::SetParametersResult validatePacketRequest(const rclcpp::Parameter& parameter);
     void updatePacketRequest(const rclcpp::Parameter& parameter);
     rcl_interfaces::msg::SetParametersResult validatePacketTimer(const rclcpp::Parameter& parameter);
@@ -280,14 +274,14 @@ class Driver : public rclcpp::Node  // Inheriting gives every "this->" as a poin
 
     //~~~~~~ Device Communication Functions
     void encodeAndSend(an_packet_t* an_packet);
-    adnav_interfaces::msg::RawAcknowledge AcknowledgeHandler();
+    adnav_interfaces::msg::RawAcknowledge sendAndAwaitAck(an_packet_t* an_packet);
+    void failAllPendingReplies();
     adnav_interfaces::msg::RawAcknowledge SendPacketTimer(int packet_timer_period, bool utc_sync = true , bool permanent = true);
     adnav_interfaces::msg::RawAcknowledge SendPacketPeriods(const std::vector<adnav_interfaces::msg::PacketPeriod>& periods,
         bool clear_existing = true, bool permanent = true);
 
     //~~~~~~ Decoders
     void decodePackets(an_decoder_t &an_decoder, const int &bytes_received);
-    void acknowledgeDecoder(an_packet_t* an_packet);
     void deviceInfoDecoder(an_packet_t* an_packet);
     void systemStateRosDecoder(an_packet_t* an_packet);
     void ecefPosRosDecoder(an_packet_t* an_packet);

--- a/adnav_driver/src/adnav_driver.hpp
+++ b/adnav_driver/src/adnav_driver.hpp
@@ -190,7 +190,6 @@ class Driver : public rclcpp::Node
     // Callback groups Allows the callbacks to be processed on a different thread by
     // the Multithread executor.
     rclcpp::CallbackGroup::SharedPtr publishing_group_;
-    rclcpp::CallbackGroup::SharedPtr reading_group_;
     rclcpp::CallbackGroup::SharedPtr service_group_;
 
     // Parameter callbacks and handlers

--- a/adnav_driver/src/adnav_driver.hpp
+++ b/adnav_driver/src/adnav_driver.hpp
@@ -91,10 +91,10 @@ namespace adnav {
     inline constexpr std::array<uint8_t, 5> REQUIRED_PACKETS = {
         {
             packet_id_system_state,
-            packet_id_raw_sensors,
             packet_id_body_velocity,
             packet_id_euler_orientation_standard_deviation,
             packet_id_velocity_standard_deviation,
+            packet_id_running_time
         }};
 
 constexpr double RADIANS_TO_DEGREES = (180.0/M_PI);
@@ -143,10 +143,12 @@ class Driver : public rclcpp::Node
     adnav::Logger rtcm_logger_;
 
     std::unordered_map<uint8_t, rclcpp::Time> packet_receive_times;
+    std::optional<rclcpp::Duration> device_running_time_;
 
     // ANPP Packet variables
     std::optional<device_information_packet_t> device_information_packet_;
     TimedBox<system_state_packet_t> system_state_packet_;
+    TimedBox<raw_sensors_packet_t> raw_sensors_packet_;
     TimedBox<euler_orientation_standard_deviation_packet_t> euler_orientation_standard_deviation_packet_;
     TimedBox<velocity_standard_deviation_packet_t> velocity_standard_deviation_packet_;
 
@@ -287,6 +289,8 @@ class Driver : public rclcpp::Node
     void rawSensorsRosDecoder(an_packet_t* an_packet);
     void extBodyVelRosDecoder(an_packet_t *an_packet);
     void bodyVelRosDecoder(an_packet_t *an_packet);
+
+    bool packet_is_recent(uint8_t packet_id, std::chrono::microseconds max_age);
 };
 
 }  // namespace adnav

--- a/adnav_driver/src/adnav_driver.hpp
+++ b/adnav_driver/src/adnav_driver.hpp
@@ -51,6 +51,7 @@
 #include <adnav_ntrip.h>
 
 #include "anpp.hpp"
+#include "utils.hpp"
 
 #include "uvw.hpp"
 
@@ -87,18 +88,13 @@
 
 namespace adnav {
 
-    struct PacketIdTime {
-        uint8_t packet_id;
-        std::chrono::microseconds period;
-    };
-
-    inline constexpr std::array<PacketIdTime, 5> REQUIRED_PACKETS = {
+    inline constexpr std::array<uint8_t, 5> REQUIRED_PACKETS = {
         {
-            {packet_id_system_state, std::chrono::microseconds(50)},
-            {packet_id_raw_sensors, std::chrono::microseconds(50)},
-            {packet_id_body_velocity, std::chrono::microseconds(50)},
-            {packet_id_euler_orientation_standard_deviation, std::chrono::microseconds(50)},
-            {packet_id_velocity_standard_deviation, std::chrono::microseconds(50)}
+            packet_id_system_state,
+            packet_id_raw_sensors,
+            packet_id_body_velocity,
+            packet_id_euler_orientation_standard_deviation,
+            packet_id_velocity_standard_deviation,
         }};
 
 constexpr double RADIANS_TO_DEGREES = (180.0/M_PI);
@@ -146,11 +142,13 @@ class Driver : public rclcpp::Node
     adnav::Logger anpp_logger_;
     adnav::Logger rtcm_logger_;
 
+    std::unordered_map<uint8_t, rclcpp::Time> packet_receive_times;
+
     // ANPP Packet variables
     std::optional<device_information_packet_t> device_information_packet_;
-    std::optional<system_state_packet_t> system_state_packet_;
-    std::optional<euler_orientation_standard_deviation_packet_t> euler_orientation_standard_deviation_packet_;
-    std::optional<velocity_standard_deviation_packet_t> velocity_standard_deviation_packet_;
+    TimedBox<system_state_packet_t> system_state_packet_;
+    TimedBox<euler_orientation_standard_deviation_packet_t> euler_orientation_standard_deviation_packet_;
+    TimedBox<velocity_standard_deviation_packet_t> velocity_standard_deviation_packet_;
 
     // Msgs. Only access with protection of messages_mutex_
     tf2::Quaternion                 orientation_;
@@ -247,6 +245,7 @@ class Driver : public rclcpp::Node
     void system_status_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
     void filter_status_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
     void accuracy_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+    void packets_diagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
 
     //~~~~~~ ROS Services
     void srvPacketTimerPeriod(const std::shared_ptr<adnav_interfaces::srv::PacketTimerPeriod::Request> request,

--- a/adnav_driver/src/adnav_parameters.yaml
+++ b/adnav_driver/src/adnav_parameters.yaml
@@ -1,15 +1,15 @@
 adnav:
-  baud_rate:
-    type: int
-    default_value: 115200
-    description: "Baud rate for serial communication with the Advanced Navigation device"
-    validation:
-      one_of<>: [[2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 576000, 921600, 1000000, 2000000]]
-  serial_port:
-    type: string
-    default_value: "/dev/ttyUSB0"
-    description: "Serial port for communication with the Advanced Navigation device"
-    read_only: true
+#  baud_rate:
+#    type: int
+#    default_value: 115200
+#    description: "Baud rate for serial communication with the Advanced Navigation device"
+#    validation:
+#      one_of<>: [[2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 576000, 921600, 1000000, 2000000]]
+#  serial_port:
+#    type: string
+#    default_value: "/dev/ttyUSB0"
+#    description: "Serial port for communication with the Advanced Navigation device"
+#    read_only: true
   publish_us:
     type: int
     default_value: 20000
@@ -29,6 +29,10 @@ adnav:
     default_value: 50
     description: "Integer value for the default packet send rate period in μs. This will be applied to all packets that are not specified in the additional_packet_request array."
   additional_packets:
+    body_velocity:
+      type: bool
+      default_value: false
+      description: "If true, the driver will request Body Velocity."
     external_body_velocity:
       type: bool
       default_value: false
@@ -47,31 +51,27 @@ adnav:
     description: "Integer value for Packet Timing Period in μs"
   connection_type:
     type: string
-    description: "Connection type to the Advanced Navigation device: Can be 'serial', 'tcp-client' or 'udp'"
+    description: "Connection type to the Advanced Navigation device: Can be 'tcp-client' or 'udp'"
     validation:
-      one_of<>: [["serial", "tcp-client", "udp"]]
+      one_of<>: [["tcp-client", "udp"]]
   ip_address:
     type: string
     default_value: ""
-    description: "IP address for communication with the Advanced Navigation device when using Ethernet connection"
+    description: "Address for communication with the Advanced Navigation device when using IP connection"
   port:
     type: int
     default_value: 16718
-    description: "Port for communication with the Advanced Navigation device when using Ethernet connection"
+    description: "Port for communication with the Advanced Navigation device when using IP connection"
     validation:
       bounds<>: [1, 65535]
   convert_twist_enu_to_flu:
     type: bool
-    default_value: false
+    default_value: true
     description: "If true, converts Twist messages from ENU to FLU frame convention."
   log_path:
     type: string
     default_value: "~/.ros/log/"
     description: "Directory path where log files will be stored"
-  use_body_velocity:
-    type: bool
-    default_value: false
-    description: "If true, use body velocity packet data instead of transforming state packet velocity."
   health:
     filters_initialised:
       type: bool

--- a/adnav_driver/src/adnav_parameters.yaml
+++ b/adnav_driver/src/adnav_parameters.yaml
@@ -1,0 +1,54 @@
+adnav:
+  baud_rate:
+    type: int
+    default_value: 115200
+    description: "Baud rate for serial communication with the Advanced Navigation device"
+    validation:
+      one_of<>: [[2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 576000, 921600, 1000000, 2000000]]
+  com_port:
+    type: string
+    default_value: "/dev/ttyUSB0"
+    description: "Serial port for communication with the Advanced Navigation device"
+    read_only: true
+  publish_us:
+    type: int
+    default_value: 20000
+    description: "Parameter for controlling the ROS topic publish period in microseconds"
+    validation:
+      bounds<>: [10000, 1000000]
+  packet_request:
+    type: int_array
+    default_value: [20, 10, 28, 10]
+    description: "Array of packet IDs and their corresponding polling frequencies in Hz. The array should be in the format [packet_id_1, frequency_1, packet_id_2, frequency_2, ...]. Supported packet IDs can be found in the AdvancedNavigation documentation."
+  packet_timer_period:
+    type: int
+    default_value: 1000
+    description: "Integer value for Packet Timing Period in μs"
+  comm_select:
+    type: int
+    default_value: 0
+    description: "Method of communication with the device. 0: Serial, 1: TCP Client, 2: TCP Server, 3: UDP Client, 4: CAN"
+    validation:
+      one_of<>: [[0, 1, 2, 3, 4]]
+  ip_address:
+    type: string
+    default_value: "0.0.0.0"
+    description: "IP address for communication with the Advanced Navigation device when using Ethernet connection"
+  port:
+    type: int
+    default_value: 16718
+    description: "Port for communication with the Advanced Navigation device when using Ethernet connection"
+    validation:
+      bounds<>: [1, 65535]
+  convert_twist_enu_to_flu:
+    type: bool
+    default_value: false
+    description: "If true, converts Twist messages from ENU to FLU frame convention."
+  log_path:
+    type: string
+    default_value: "~/.ros/log/"
+    description: "Directory path where log files will be stored"
+  use_body_velocity:
+    type: bool
+    default_value: false
+    description: "If true, use body velocity packet data instead of transforming state packet velocity."

--- a/adnav_driver/src/adnav_parameters.yaml
+++ b/adnav_driver/src/adnav_parameters.yaml
@@ -20,18 +20,27 @@ adnav:
     type: bool
     default_value: true
     description: "If true, the driver will configure the packet periods overriding the default settings on the device."
-  default_packet_period:
-    type: int
-    default_value: 50
-    description: "Integer value for the default packet send rate period in μs. This will be applied to all packets that are not specified in the additional_packet_request array."
-  additional_packet_request:
-    type: int_array
-    default_value: []
-    description: "Array of additional packet IDs and their corresponding polling frequencies in microseconds. The array should be in the format [packet_id_1, period_1, packet_id_2, period_2, ...]. Supported packet IDs can be found in the AdvancedNavigation documentation."
   override_existing_packets:
     type: bool
     default_value: true
     description: "The existing existing packet ids and periods will be cleared on the device."
+  default_packet_period:
+    type: int
+    default_value: 50
+    description: "Integer value for the default packet send rate period in μs. This will be applied to all packets that are not specified in the additional_packet_request array."
+  additional_packets:
+    external_body_velocity:
+      type: bool
+      default_value: false
+      description: "If true, the driver will request External Body Velocity."
+    ecef_position:
+      type: bool
+      default_value: false
+      description: "If true, the driver will request ECEF Position."
+    raw_sensors:
+      type: bool
+      default_value: false
+      description: "If true, the driver will request Raw Sensors data."
   packet_timer_period:
     type: int
     default_value: 1000
@@ -71,7 +80,7 @@ adnav:
     gnss_fix:
         type: bool
         default_value: true
-        description: "Require a valid 3D GNSS fix for the device to be considered healthy."
+        description: "Require a precise GNSS fix (3D or better) for the device to be considered healthy."
     external_velocity:
       type: bool
       default_value: false

--- a/adnav_driver/src/adnav_parameters.yaml
+++ b/adnav_driver/src/adnav_parameters.yaml
@@ -16,10 +16,14 @@ adnav:
     description: "Parameter for controlling the ROS topic publish period in microseconds"
     validation:
       bounds<>: [10000, 1000000]
-  packet_request:
+  send_packet_periods:
+    type: bool
+    default_value: true
+    description: "If true, the driver will configure the packet periods overriding the default settings on the device."
+  additional_packet_request:
     type: int_array
-    default_value: [20, 10, 28, 10]
-    description: "Array of packet IDs and their corresponding polling frequencies in Hz. The array should be in the format [packet_id_1, frequency_1, packet_id_2, frequency_2, ...]. Supported packet IDs can be found in the AdvancedNavigation documentation."
+    default_value: []
+    description: "Array of additional packet IDs and their corresponding polling frequencies in microseconds. The array should be in the format [packet_id_1, period_1, packet_id_2, period_2, ...]. Supported packet IDs can be found in the AdvancedNavigation documentation."
   packet_timer_period:
     type: int
     default_value: 1000
@@ -32,8 +36,12 @@ adnav:
       one_of<>: [[0, 1, 2, 3, 4]]
   ip_address:
     type: string
-    default_value: "0.0.0.0"
+    default_value: ""
     description: "IP address for communication with the Advanced Navigation device when using Ethernet connection"
+  ip_address_local:
+    type: string
+    default_value: ""
+    description: "IP address of the host that will receive the UDP packets. This is only used when using UDP."
   port:
     type: int
     default_value: 16718
@@ -52,3 +60,38 @@ adnav:
     type: bool
     default_value: false
     description: "If true, use body velocity packet data instead of transforming state packet velocity."
+  health:
+    filters_initialised:
+      type: bool
+      default_value: true
+      description: "Require orientation, navigation and heading to be initialised."
+    gnss_fix:
+        type: bool
+        default_value: true
+        description: "Require a valid 3D GNSS fix for the device to be considered healthy."
+    thresholds:
+      position_accuracy_rms_2d:
+          type: double
+          default_value: 0.0
+          description: "Maximum acceptable 2D position accuracy (RMS) in meters for the device to be considered healthy. 0.0 means this check is disabled."
+          additional_constraints: '{"type": "number", "units": "meters"}'
+      position_accuracy_rms_3d:
+          type: double
+          default_value: 0.0
+          description: "Maximum acceptable 3D position accuracy (RMS) in meters for the device to be considered healthy. 0.0 means this check is disabled."
+          additional_constraints: '{"type": "number", "units": "meters"}'
+      velocity_accuracy_rms_2d:
+          type: double
+          default_value: 0.0
+          description: "Maximum acceptable 2D velocity accuracy (RMS) in meters per second for the device to be considered healthy. 0.0 means this check is disabled."
+          additional_constraints: '{"type": "number", "units": "metersPerSecond"}'
+      velocity_accuracy_rms_3d:
+        type: double
+        default_value: 0.0
+        description: "Maximum acceptable 3D velocity accuracy (RMS) in meters per second for the device to be considered healthy. 0.0 means this check is disabled."
+        additional_constraints: '{"type": "number", "units": "metersPerSecond"}'
+      orientation_accuracy_stdev:
+          type: double
+          default_value: 0.0
+          description: "Maximum acceptable orientation accuracy (standard deviation) in rads for the device to be considered healthy. 0.0 means this check is disabled."
+          additional_constraints: '{"type": "number", "units": "radians"}'

--- a/adnav_driver/src/adnav_parameters.yaml
+++ b/adnav_driver/src/adnav_parameters.yaml
@@ -5,7 +5,7 @@ adnav:
     description: "Baud rate for serial communication with the Advanced Navigation device"
     validation:
       one_of<>: [[2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 576000, 921600, 1000000, 2000000]]
-  com_port:
+  serial_port:
     type: string
     default_value: "/dev/ttyUSB0"
     description: "Serial port for communication with the Advanced Navigation device"
@@ -20,10 +20,18 @@ adnav:
     type: bool
     default_value: true
     description: "If true, the driver will configure the packet periods overriding the default settings on the device."
+  default_packet_period:
+    type: int
+    default_value: 50
+    description: "Integer value for the default packet send rate period in μs. This will be applied to all packets that are not specified in the additional_packet_request array."
   additional_packet_request:
     type: int_array
     default_value: []
     description: "Array of additional packet IDs and their corresponding polling frequencies in microseconds. The array should be in the format [packet_id_1, period_1, packet_id_2, period_2, ...]. Supported packet IDs can be found in the AdvancedNavigation documentation."
+  override_existing_packets:
+    type: bool
+    default_value: true
+    description: "The existing existing packet ids and periods will be cleared on the device."
   packet_timer_period:
     type: int
     default_value: 1000
@@ -37,10 +45,6 @@ adnav:
     type: string
     default_value: ""
     description: "IP address for communication with the Advanced Navigation device when using Ethernet connection"
-  ip_address_local:
-    type: string
-    default_value: ""
-    description: "IP address of the host that will receive the UDP packets. This is only used when using UDP."
   port:
     type: int
     default_value: 16718

--- a/adnav_driver/src/adnav_parameters.yaml
+++ b/adnav_driver/src/adnav_parameters.yaml
@@ -28,12 +28,11 @@ adnav:
     type: int
     default_value: 1000
     description: "Integer value for Packet Timing Period in μs"
-  comm_select:
-    type: int
-    default_value: 0
-    description: "Method of communication with the device. 0: Serial, 1: TCP Client, 2: TCP Server, 3: UDP Client, 4: CAN"
+  connection_type:
+    type: string
+    description: "Connection type to the Advanced Navigation device: Can be 'serial', 'tcp-client' or 'udp'"
     validation:
-      one_of<>: [[0, 1, 2, 3, 4]]
+      one_of<>: [["serial", "tcp-client", "udp"]]
   ip_address:
     type: string
     default_value: ""

--- a/adnav_driver/src/adnav_parameters.yaml
+++ b/adnav_driver/src/adnav_parameters.yaml
@@ -85,6 +85,10 @@ adnav:
       type: bool
       default_value: false
       description: "Require the External Velocity Active flag, i.e. DVL signal is valid."
+    sensors_in_range:
+      type: bool
+      default_value: true
+      description: "Require no sensor over-range errors."
     thresholds:
       position_accuracy_rms_2d:
           type: double

--- a/adnav_driver/src/adnav_parameters.yaml
+++ b/adnav_driver/src/adnav_parameters.yaml
@@ -68,6 +68,10 @@ adnav:
         type: bool
         default_value: true
         description: "Require a valid 3D GNSS fix for the device to be considered healthy."
+    external_velocity:
+      type: bool
+      default_value: false
+      description: "Require the External Velocity Active flag, i.e. DVL signal is valid."
     thresholds:
       position_accuracy_rms_2d:
           type: double

--- a/adnav_driver/src/anpp.hpp
+++ b/adnav_driver/src/anpp.hpp
@@ -1,0 +1,64 @@
+#pragma once
+#include <cstdint>
+#include <string>
+
+enum class FilterStatusBit : uint16_t {
+    OrientationFilterInitialised = (1u << 0),
+    NavigationFilterInitialised  = (1u << 1),
+    HeadingInitialised           = (1u << 2),
+    UtcTimeInitialised           = (1u << 3),
+    // Bits 4–6: GNSS fix status — NOT individual flags, use gnss_fix_status()
+    Event1Occurred               = (1u << 7),
+    Event2Occurred               = (1u << 8),
+    InternalGnssEnabled          = (1u << 9),
+    DualAntennaHeadingActive     = (1u << 10),
+    VelocityHeadingEnabled       = (1u << 11),
+    AtmosphericAltitudeEnabled   = (1u << 12),
+    ExternalPositionActive       = (1u << 13),
+    ExternalVelocityActive       = (1u << 14),
+    ExternalHeadingActive        = (1u << 15),
+};
+
+enum class GnssFixStatus : uint8_t {
+    NoFix          = 0,
+    Fix2D          = 1,
+    Fix3D          = 2,
+    SbasFix        = 3,
+    DifferentialFix = 4,
+    PppFix         = 5,
+    RtkFloat       = 6,
+    RtkFixed       = 7,
+};
+
+inline std::string to_string(const FilterStatusBit bit) {
+    switch (bit) {
+        case FilterStatusBit::OrientationFilterInitialised: return "Orientation Filter Initialised";
+        case FilterStatusBit::NavigationFilterInitialised: return "Navigation Filter Initialised";
+        case FilterStatusBit::HeadingInitialised: return "Heading Initialised";
+        case FilterStatusBit::UtcTimeInitialised: return "UTC Time Initialised";
+        case FilterStatusBit::Event1Occurred: return "Event 1 Occurred";
+        case FilterStatusBit::Event2Occurred: return "Event 2 Occurred";
+        case FilterStatusBit::InternalGnssEnabled: return "Internal GNSS Enabled";
+        case FilterStatusBit::DualAntennaHeadingActive: return "Dual Antenna Heading Active";
+        case FilterStatusBit::VelocityHeadingEnabled: return "Velocity Heading Enabled";
+        case FilterStatusBit::AtmosphericAltitudeEnabled: return "Atmospheric Altitude Enabled";
+        case FilterStatusBit::ExternalPositionActive: return "External Position Active";
+        case FilterStatusBit::ExternalVelocityActive: return "External Velocity Active";
+        case FilterStatusBit::ExternalHeadingActive: return "External Heading Active";
+    }
+    return "Unknown Bit";
+}
+
+inline std::string to_string(const GnssFixStatus status) {
+    switch (status) {
+        case GnssFixStatus::NoFix: return "No Fix";
+        case GnssFixStatus::Fix2D: return "2D Fix";
+        case GnssFixStatus::Fix3D: return "3D Fix";
+        case GnssFixStatus::SbasFix: return "SBAS Fix";
+        case GnssFixStatus::DifferentialFix: return "Differential Fix";
+        case GnssFixStatus::PppFix: return "PPP Fix";
+        case GnssFixStatus::RtkFloat: return "RTK Float";
+        case GnssFixStatus::RtkFixed: return "RTK Fixed";
+    }
+    return "Unknown Status";
+}

--- a/adnav_driver/src/anpp.hpp
+++ b/adnav_driver/src/anpp.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <string>
+#include "ins_packets.h"
 
 enum class FilterStatusBit : uint16_t {
     OrientationFilterInitialised = (1u << 0),
@@ -61,4 +62,103 @@ inline std::string to_string(const GnssFixStatus status) {
         case GnssFixStatus::RtkFixed: return "RTK Fixed";
     }
     return "Unknown Status";
+}
+
+inline std::optional<std::string> packet_id_to_string(packet_id_e p_id)
+{
+	switch (p_id)
+	{
+		case packet_id_acknowledge: return "Acknowledge";
+		case packet_id_request: return "Request";
+		case packet_id_boot_mode: return "Boot Mode";
+		case packet_id_device_information: return "Device Information";
+		case packet_id_restore_factory_settings: return "Restore Factory Settings";
+		case packet_id_reset: return "Reset";
+		case packet_id_file_transfer_request: return "File Transfer Request";
+		case packet_id_file_transfer_acknowledge: return "File Transfer Acknowledge";
+		case packet_id_file_transfer: return "File Transfer";
+		case packet_id_serial_port_passthrough: return "Serial Port Passthrough";
+		case packet_id_ip_configuration: return "IP Configuration";
+		case packet_id_extended_device_information: return "Extended Device Information";
+		case packet_id_subcomponent_information: return "Subcomponent Information";
+
+		case packet_id_system_state: return "System State";
+		case packet_id_unix_time: return "Unix Time";
+		case packet_id_formatted_time: return "Formatted Time";
+		case packet_id_status: return "Status";
+		case packet_id_position_standard_deviation: return "Position Standard Deviation";
+		case packet_id_velocity_standard_deviation: return "Velocity Standard Deviation";
+		case packet_id_euler_orientation_standard_deviation: return "Euler Orientation Standard Deviation";
+		case packet_id_quaternion_orientation_standard_deviation: return "Quaternion Orientation Standard Deviation";
+		case packet_id_raw_sensors: return "Raw Sensors";
+		case packet_id_raw_gnss: return "Raw GNSS";
+		case packet_id_satellites: return "Satellites";
+		case packet_id_satellites_detailed: return "Satellites Detailed";
+		case packet_id_geodetic_position: return "Geodetic Position";
+		case packet_id_ecef_position: return "ECEF Position";
+		case packet_id_utm_position: return "UTM Position";
+		case packet_id_ned_velocity: return "NED Velocity";
+		case packet_id_body_velocity: return "Body Velocity";
+		case packet_id_acceleration: return "Acceleration";
+		case packet_id_body_acceleration: return "Body Acceleration";
+		case packet_id_euler_orientation: return "Euler Orientation";
+		case packet_id_quaternion_orientation: return "Quaternion Orientation";
+		case packet_id_dcm_orientation: return "DCM Orientation";
+		case packet_id_angular_velocity: return "Angular Velocity";
+		case packet_id_angular_acceleration: return "Angular Acceleration";
+		case packet_id_external_position_velocity: return "External Position Velocity";
+		case packet_id_external_position: return "External Position";
+		case packet_id_external_velocity: return "External Velocity";
+		case packet_id_external_body_velocity: return "External Body Velocity";
+		case packet_id_external_heading: return "External Heading";
+		case packet_id_running_time: return "Running Time";
+		case packet_id_local_magnetics: return "Local Magnetics";
+		case packet_id_odometer_state: return "Odometer State";
+		case packet_id_external_time: return "External Time";
+		case packet_id_external_depth: return "External Depth";
+		case packet_id_geoid_height: return "Geoid Height";
+		case packet_id_rtcm_corrections: return "RTCM Corrections";
+		case packet_id_wind: return "Wind";
+		case packet_id_heave: return "Heave";
+		case packet_id_raw_satellite_data: return "Raw Satellite Data";
+		case packet_id_raw_satellite_ephemeris: return "Raw Satellite Ephemeris";
+		case packet_id_external_odometer: return "External Odometer";
+		case packet_id_external_air_data: return "External Air Data";
+		case packet_id_gnss_receiver_information: return "GNSS Receiver Information";
+		case packet_id_raw_dvl_data: return "Raw DVL Data";
+		case packet_id_north_seeking_status: return "North Seeking Status";
+		case packet_id_gimbal_state: return "Gimbal State";
+		case packet_id_automotive: return "Automotive";
+		case packet_id_external_magnetometers: return "External Magnetometers";
+		case packet_id_basestation: return "Basestation";
+		case packet_id_zero_angular_velocity: return "Zero Angular Velocity";
+		case packet_id_extended_satellites: return "Extended Satellites";
+		case packet_id_sensor_temperatures: return "Sensor Temperatures";
+		case packet_id_system_temperature: return "System Temperature";
+		case packet_id_quantum_sensor: return "Quantum Sensor";
+
+		case packet_id_packet_timer_period: return "Packet Timer Period";
+		case packet_id_packet_periods: return "Packet Periods";
+		case packet_id_baud_rates: return "Baud Rates";
+		case packet_id_sensor_ranges: return "Sensor Ranges";
+		case packet_id_installation_alignment: return "Installation Alignment";
+		case packet_id_filter_options: return "Filter Options";
+		case packet_id_gpio_configuration: return "GPIO Configuration";
+		case packet_id_magnetic_calibration_values: return "Magnetic Calibration Values";
+		case packet_id_magnetic_calibration_configuration: return "Magnetic Calibration Configuration";
+		case packet_id_magnetic_calibration_status: return "Magnetic Calibration Status";
+		case packet_id_odometer_configuration: return "Odometer Configuration";
+		case packet_id_zero_alignment: return "Zero Alignment";
+		case packet_id_reference_offsets: return "Reference Offsets";
+		case packet_id_gpio_output_configuration: return "GPIO Output Configuration";
+		case packet_id_dual_antenna_configuration: return "Dual Antenna Configuration";
+		case packet_id_gnss_configuration: return "GNSS Configuration";
+		case packet_id_user_data: return "User Data";
+		case packet_id_gpio_input_configuration: return "GPIO Input Configuration";
+		case packet_id_ip_dataports_configuration: return "IP Dataports Configuration";
+		case packet_id_can_configuration: return "CAN Configuration";
+
+		default:
+			return std::nullopt;
+	}
 }

--- a/adnav_driver/src/main.cpp
+++ b/adnav_driver/src/main.cpp
@@ -41,10 +41,7 @@ int main(int argc, char * argv[])
 
 	// Add the driver node to the executor and spin it.
 	executor.add_node(node);
-
-	while(rclcpp::ok()) {
-		executor.spin();
-	}
+	executor.spin();
 
 	rclcpp::shutdown();
   	return 0;

--- a/adnav_driver/src/main.cpp
+++ b/adnav_driver/src/main.cpp
@@ -26,7 +26,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "adnav_driver.h"
+#include "adnav_driver.hpp"
 
 int main(int argc, char * argv[])
 {

--- a/adnav_driver/src/utils.hpp
+++ b/adnav_driver/src/utils.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <expected>
+#include <optional>
+
+template <typename T>
+concept ChronoDuration = requires {
+  typename T::rep;
+  typename T::period;
+  requires std::is_same_v<T, std::chrono::duration<typename T::rep, typename T::period>>;
+};
+
+enum class TimedBoxErrors
+{
+  Expired,
+  NotSet
+};
+
+/**
+ * @brief A box that holds a item for a certain lifespan
+ * @tparam ItemT The item type
+ */
+template <typename ItemT>
+class TimedBox
+{
+public:
+
+  using TimePoint = std::chrono::time_point<std::chrono::system_clock>;
+
+  struct ItemContainer
+  {
+    ItemT item;
+    TimePoint set_time;
+  };
+
+  /**
+ * @brief Construct a new TimedBox with no lifespan
+ */
+  explicit TimedBox()
+  {
+  }
+
+  /**
+   * @brief Construct a new TimedBox
+   * @param lifespan The lifespan for the subscriber before it returns an Expired error
+   */
+  template <ChronoDuration DurationT>
+  explicit TimedBox(
+    const DurationT& lifespan)
+  {
+    set_lifespan(lifespan);
+  }
+
+  template <ChronoDuration DurationT>
+  void set_lifespan(const DurationT & lifespan)
+  {
+    lifespan_ = std::chrono::duration_cast<std::chrono::milliseconds>(lifespan);
+  }
+
+  void set(const ItemT& item) {
+      auto incoming_item = ItemContainer{item, std::chrono::system_clock::now()};
+      item_ = incoming_item;
+  }
+
+  TimedBox& operator=(const ItemT& item) {
+    set(item);
+    return *this;
+  }
+
+  /**
+   * @brief Get the item as an Expected, or reason why it is not available
+   * @return The item or an error enum
+   */
+  std::expected<ItemT, TimedBoxErrors> value() const
+  {
+    if (!item_) {
+      return std::unexpected(TimedBoxErrors::NotSet);
+    }
+    if (is_expired()) {
+      return std::unexpected(TimedBoxErrors::Expired);
+    }
+    return item_.value().item;
+  }
+
+  /**
+   * @brief Get the item or a default value if it is not available
+   * @param default_value The default value to return if the item is not available
+   * @return The item or the default value
+   */
+  ItemT value_or(const ItemT& default_value) const
+  {
+    auto val = value();
+    if (val) {
+      return val.value();
+    }
+    return default_value;
+  }
+
+  /**
+   * @brief Get the time the item was last set.
+   *
+   * @return std::optional<TimePoint> Last set time
+   */
+  [[nodiscard]] std::optional<TimePoint> get_last_set_time() const
+  {
+    return item_ ? std::optional<TimePoint>(item_.value().set_time) : std::nullopt;
+  }
+
+  /**
+   * @brief Check if the item is expired
+   * @return True if the item is expired, or has never been set
+   */
+  [[nodiscard]] bool is_expired() const
+  {
+    if (!item_) {
+      // if the item has never been set, consider it expired
+      return true;
+    }
+
+    if (!lifespan_.has_value()) {
+      // if no lifespan is set, the item should not be considered expired
+      return false;
+    }
+
+    return is_expired(item_.value());
+  }
+
+protected:
+
+  /**
+   * @brief Check if the item is expired
+   * @param item_container The item container
+   * @return True if the item is expired
+   */
+  [[nodiscard]] bool is_expired(const ItemContainer & item_container) const
+  {
+    const auto time_since_last_item = std::chrono::system_clock::now() - item_container.set_time;
+    return time_since_last_item > lifespan_;
+  }
+
+  std::optional<ItemContainer> item_;
+  std::optional<std::chrono::milliseconds> lifespan_;
+};
+
+inline std::string to_string(TimedBoxErrors e)
+{
+  switch (e) {
+    case TimedBoxErrors::Expired: return "Item lifespan expired";
+    case TimedBoxErrors::NotSet:  return "Item has not been set";
+    default:         return "Unknown TimedBox error";
+  }
+}

--- a/adnav_interfaces/package.xml
+++ b/adnav_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>adnav_interfaces</name>
-  <version>2.1.1</version>
+  <version>2.2.1</version>
   <description>Advanced Navigation ROS 2 Driver Interfaces</description>
   <maintainer email="support@advancednavigation.com">Support</maintainer>
   <license>MIT</license>

--- a/adnav_launch/config/adnav_udp_client.yaml
+++ b/adnav_launch/config/adnav_udp_client.yaml
@@ -24,7 +24,7 @@ adnav_node:
 
     # This is the minimum period for reading and publishing data.
     # Warning on some systems this is performance limited.  
-    # The configuration will be rejected if publissh_us < read_us
+    # The configuration will be rejected if publish_us < read_us
     # Units are in μs. 20000 = 50Hz | 1000 = 1000Hz etc.
     publish_us: 20000
     read_us: 1000

--- a/adnav_launch/launch/adnav_serial.launch.py
+++ b/adnav_launch/launch/adnav_serial.launch.py
@@ -22,7 +22,5 @@ def generate_launch_description():
         parameters = [config]        
     )
 
-    ld.add_action
-
     ld.add_action(node)
     return ld

--- a/adnav_launch/launch/adnav_tcp_client.launch.py
+++ b/adnav_launch/launch/adnav_tcp_client.launch.py
@@ -22,7 +22,5 @@ def generate_launch_description():
         parameters = [config]
     )
 
-    ld.add_action
-
     ld.add_action(node)
     return ld

--- a/adnav_launch/launch/adnav_tcp_server.launch.py
+++ b/adnav_launch/launch/adnav_tcp_server.launch.py
@@ -22,7 +22,5 @@ def generate_launch_description():
         parameters = [config]
     )
 
-    ld.add_action
-
     ld.add_action(node)
     return ld

--- a/adnav_launch/launch/adnav_udp_client.launch.py
+++ b/adnav_launch/launch/adnav_udp_client.launch.py
@@ -22,7 +22,5 @@ def generate_launch_description():
         parameters = [config]
     )
 
-    ld.add_action
-
     ld.add_action(node)
     return ld


### PR DESCRIPTION
AdNav reports orientation as FRD body in a NED world; ROS (REP 103) expects FLU body in an ENU  world. The FRD→FLU body flip negates pitch (Y axis flips right→left), and the NED→ENU world flip is already handled by π/2 − heading for yaw. The current code only did the yaw correction, so pitch came out inverted. This matches the [older working driver in         platform_ins/packages/adnav-ros2-beta](https://github.com/greenroom-robotics/platform_ins/blob/f65355a5ecd2386cbfdfefb2abd521b529f75ac6/packages/adnav-ros2-beta/adnav_driver/src/adnav_driver.cpp#L1819), which also negated only pitch - roll worked without a flip.